### PR TITLE
Feat/add listing to aave v2 configurator

### DIFF
--- a/scripts/AaveV2ConfigEngine.s.sol
+++ b/scripts/AaveV2ConfigEngine.s.sol
@@ -5,51 +5,53 @@ import {AaveV2ConfigEngine} from '../src/v2-config-engine/AaveV2ConfigEngine.sol
 import {IV2RateStrategyFactory} from '../src/v2-config-engine/IV2RateStrategyFactory.sol';
 import '../src/ScriptUtils.sol';
 
+// TODO
+
 library DeployV2EngineEthLib {
   function deploy(address ratesFactory) internal returns (address) {
-    return
-      address(
-        new AaveV2ConfigEngine(
-          AaveV2Ethereum.POOL_CONFIGURATOR,
-          IV2RateStrategyFactory(ratesFactory)
-        )
-      );
+    // return
+    //   address(
+    //     new AaveV2ConfigEngine(
+    //       AaveV2Ethereum.POOL_CONFIGURATOR,
+    //       IV2RateStrategyFactory(ratesFactory)
+    //     )
+    //   );
   }
 }
 
 library DeployV2EngineEthAMMLib {
   function deploy(address ratesFactory) internal returns (address) {
-    return
-      address(
-        new AaveV2ConfigEngine(
-          AaveV2EthereumAMM.POOL_CONFIGURATOR,
-          IV2RateStrategyFactory(ratesFactory)
-        )
-      );
+    //   return
+    //     address(
+    //       new AaveV2ConfigEngine(
+    //         AaveV2EthereumAMM.POOL_CONFIGURATOR,
+    //         IV2RateStrategyFactory(ratesFactory)
+    //       )
+    //     );
   }
 }
 
 library DeployV2EnginePolLib {
   function deploy(address ratesFactory) internal returns (address) {
-    return
-      address(
-        new AaveV2ConfigEngine(
-          AaveV2Polygon.POOL_CONFIGURATOR,
-          IV2RateStrategyFactory(ratesFactory)
-        )
-      );
+    // return
+    //   address(
+    //     new AaveV2ConfigEngine(
+    //       AaveV2Polygon.POOL_CONFIGURATOR,
+    //       IV2RateStrategyFactory(ratesFactory)
+    //     )
+    //   );
   }
 }
 
 library DeployV2EngineAvaLib {
   function deploy(address ratesFactory) internal returns (address) {
-    return
-      address(
-        new AaveV2ConfigEngine(
-          AaveV2Avalanche.POOL_CONFIGURATOR,
-          IV2RateStrategyFactory(ratesFactory)
-        )
-      );
+    // return
+    //   address(
+    //     new AaveV2ConfigEngine(
+    //       AaveV2Avalanche.POOL_CONFIGURATOR,
+    //       IV2RateStrategyFactory(ratesFactory)
+    //     )
+    //   );
   }
 }
 

--- a/src/v2-config-engine/AaveV2ConfigEngine.sol
+++ b/src/v2-config-engine/AaveV2ConfigEngine.sol
@@ -2,9 +2,12 @@
 pragma solidity ^0.8.12;
 
 import {ListingV2Engine as ListingEngine} from './libraries/ListingV2Engine.sol';
-import {RateV2Engine as RatingEngine} from './libraries/RateV2Engine.sol';
+import {CollateralV2Engine as CollateralEngine} from './libraries/CollateralV2Engine.sol';
+import {BorrowV2Engine as BorrowEngine} from './libraries/BorrowV2Engine.sol';
+import {RateV2Engine as RateEngine} from './libraries/RateV2Engine.sol';
 import {EngineFlags} from '../v3-config-engine/EngineFlags.sol';
 import './IAaveV2ConfigEngine.sol';
+import {Address} from 'solidity-utils/contracts/oz-common/Address.sol';
 
 /**
  * @dev Helper smart contract abstracting the complexity of changing rates configurations on Aave v2.
@@ -13,17 +16,17 @@ import './IAaveV2ConfigEngine.sol';
  * @author BGD Labs
  */
 contract AaveV2ConfigEngine is IAaveV2ConfigEngine {
-  struct AssetsConfig {
-    address[] ids;
-    IV2RateStrategyFactory.RateStrategyParams[] rates;
-  }
+  using Address for address;
 
   ILendingPool public immutable POOL;
   ILendingPoolConfigurator public immutable POOL_CONFIGURATOR;
-  IV2RateStrategyFactory public immutable RATE_STRATEGIES_FACTORY;
+  IV2RateStrategyFactory public immutable RATE_STRATEGY_FACTORY;
+  IAaveOracle public immutable ORACLE;
   address public immutable ATOKEN_IMPL;
   address public immutable VTOKEN_IMPL;
   address public immutable STOKEN_IMPL;
+  address public immutable REWARDS_CONTROLLER;
+  address public immutable COLLECTOR;
 
   address public immutable BORROW_ENGINE;
   address public immutable COLLATERAL_ENGINE;
@@ -58,7 +61,16 @@ contract AaveV2ConfigEngine is IAaveV2ConfigEngine {
     STOKEN_IMPL = sTokenImpl;
     POOL = engineConstants.pool;
     POOL_CONFIGURATOR = engineConstants.poolConfigurator;
-    RATE_STRATEGIES_FACTORY = rateStrategiesFactory;
+    ORACLE = engineConstants.oracle;
+    REWARDS_CONTROLLER = engineConstants.rewardsController;
+    COLLECTOR = engineConstants.collector;
+    RATE_STRATEGY_FACTORY = engineConstants.ratesStrategyFactory;
+
+    BORROW_ENGINE = engineLibraries.borrowEngine;
+    COLLATERAL_ENGINE = engineLibraries.collateralEngine;
+    LISTING_ENGINE = engineLibraries.listingEngine;
+    PRICE_FEED_ENGINE = engineLibraries.priceFeedEngine;
+    RATE_ENGINE = engineLibraries.rateEngine;
   }
 
   /// @inheritdoc IAaveV2ConfigEngine

--- a/src/v2-config-engine/AaveV2ConfigEngine.sol
+++ b/src/v2-config-engine/AaveV2ConfigEngine.sol
@@ -5,6 +5,7 @@ import {ListingV2Engine as ListingEngine} from './libraries/ListingV2Engine.sol'
 import {CollateralV2Engine as CollateralEngine} from './libraries/CollateralV2Engine.sol';
 import {BorrowV2Engine as BorrowEngine} from './libraries/BorrowV2Engine.sol';
 import {RateV2Engine as RateEngine} from './libraries/RateV2Engine.sol';
+import {PriceFeedEngine} from '../v3-config-engine/libraries/PriceFeedEngine.sol';
 import {EngineFlags} from '../v3-config-engine/EngineFlags.sol';
 import './IAaveV2ConfigEngine.sol';
 import {Address} from 'solidity-utils/contracts/oz-common/Address.sol';
@@ -113,6 +114,39 @@ contract AaveV2ConfigEngine is IAaveV2ConfigEngine {
     RATE_ENGINE.functionDelegateCall(
       abi.encodeWithSelector(
         RateEngine.executeRateStrategiesUpdate.selector,
+        _getEngineConstants(),
+        updates
+      )
+    );
+  }
+
+  /// @inheritdoc IAaveV2ConfigEngine
+  function updatePriceFeeds(PriceFeedUpdate[] calldata updates) external {
+    PRICE_FEED_ENGINE.functionDelegateCall(
+      abi.encodeWithSelector(
+        PriceFeedEngine.executePriceFeedsUpdate.selector,
+        _getEngineConstants(),
+        updates
+      )
+    );
+  }
+
+  /// @inheritdoc IAaveV2ConfigEngine
+  function updateCollateralSide(CollateralUpdate[] calldata updates) external {
+    COLLATERAL_ENGINE.functionDelegateCall(
+      abi.encodeWithSelector(
+        CollateralEngine.executeCollateralSide.selector,
+        _getEngineConstants(),
+        updates
+      )
+    );
+  }
+
+  /// @inheritdoc IAaveV2ConfigEngine
+  function updateBorrowSide(BorrowUpdate[] calldata updates) external {
+    BORROW_ENGINE.functionDelegateCall(
+      abi.encodeWithSelector(
+        BorrowEngine.executeBorrowSide.selector,
         _getEngineConstants(),
         updates
       )

--- a/src/v2-config-engine/AaveV2Payload.sol
+++ b/src/v2-config-engine/AaveV2Payload.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {Address} from 'solidity-utils/contracts/oz-common/Address.sol';
-import {WadRayMath} from 'aave-v3-core/contracts/protocol/libraries/math/WadRayMath.sol';
-import {IAaveV2ConfigEngine as IEngine} from './IAaveV2ConfigEngine.sol';
-import {IV2RateStrategyFactory} from './IV2RateStrategyFactory.sol';
-import {EngineFlags} from '../v3-config-engine/EngineFlags.sol';
+import {Address} from "solidity-utils/contracts/oz-common/Address.sol";
+import {WadRayMath} from "aave-v3-core/contracts/protocol/libraries/math/WadRayMath.sol";
+import {IAaveV2ConfigEngine as IEngine} from "./IAaveV2ConfigEngine.sol";
+import {IV2RateStrategyFactory} from "./IV2RateStrategyFactory.sol";
+import {EngineFlags} from "../v3-config-engine/EngineFlags.sol";
 
 /**
  * @dev Base smart contract for an Aave v3.0.1 configs update.
@@ -17,46 +17,42 @@ import {EngineFlags} from '../v3-config-engine/EngineFlags.sol';
  * @author BGD Labs
  */
 abstract contract AaveV2Payload {
-  using Address for address;
+    using Address for address;
 
-  IEngine public immutable LISTING_ENGINE;
+    IEngine public immutable LISTING_ENGINE;
 
-  constructor(IEngine engine) {
-    LISTING_ENGINE = engine;
-  }
-
-  /// @dev to be overriden on the child if any extra logic is needed pre-listing
-  function _preExecute() internal virtual {}
-
-  /// @dev to be overriden on the child if any extra logic is needed post-listing
-  function _postExecute() internal virtual {}
-
-  function execute() external {
-    _preExecute();
-
-    IEngine.RateStrategyUpdate[] memory rates = rateStrategiesUpdates();
-
-    if (rates.length != 0) {
-      address(LISTING_ENGINE).functionDelegateCall(
-        abi.encodeWithSelector(LISTING_ENGINE.updateRateStrategies.selector, rates)
-      );
+    constructor(IEngine engine) {
+        LISTING_ENGINE = engine;
     }
 
-    _postExecute();
-  }
+    /// @dev to be overriden on the child if any extra logic is needed pre-listing
+    function _preExecute() internal virtual {}
 
-  /** @dev Converts basis points to RAY units
-   * e.g. 10_00 (10.00%) will return 100000000000000000000000000
-   */
-  function _bpsToRay(uint256 amount) internal pure returns (uint256) {
-    return (amount * WadRayMath.RAY) / 10_000;
-  }
+    /// @dev to be overriden on the child if any extra logic is needed post-listing
+    function _postExecute() internal virtual {}
 
-  /// @dev to be defined in the child with a list of set of parameters of rate strategies
-  function rateStrategiesUpdates()
-    public
-    view
-    virtual
-    returns (IEngine.RateStrategyUpdate[] memory)
-  {}
+    function execute() external {
+        _preExecute();
+
+        IEngine.RateStrategyUpdate[] memory rates = rateStrategiesUpdates();
+
+        if (rates.length != 0) {
+            address(LISTING_ENGINE).functionDelegateCall(
+                abi.encodeWithSelector(LISTING_ENGINE.updateRateStrategies.selector, rates)
+            );
+        }
+
+        _postExecute();
+    }
+
+    /**
+     * @dev Converts basis points to RAY units
+     * e.g. 10_00 (10.00%) will return 100000000000000000000000000
+     */
+    function _bpsToRay(uint256 amount) internal pure returns (uint256) {
+        return (amount * WadRayMath.RAY) / 10_000;
+    }
+
+    /// @dev to be defined in the child with a list of set of parameters of rate strategies
+    function rateStrategiesUpdates() public view virtual returns (IEngine.RateStrategyUpdate[] memory) {}
 }

--- a/src/v2-config-engine/AaveV2PayloadAvalanche.sol
+++ b/src/v2-config-engine/AaveV2PayloadAvalanche.sol
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {AaveV2Avalanche} from 'aave-address-book/AaveV2Avalanche.sol';
-import './AaveV2Payload.sol';
+import {AaveV2Avalanche} from "aave-address-book/AaveV2Avalanche.sol";
+import "./AaveV2Payload.sol";
 
 /**
  * @dev Base smart contract for an Aave v2 rates update on Avalanche.
  * @author BGD Labs
  */
 // TODO: Add rates factory address after deploying
-abstract contract AaveV2PayloadAvalanche is AaveV2Payload(IEngine(AaveV2Avalanche.CONFIG_ENGINE)) {
-
-}
+abstract contract AaveV2PayloadAvalanche is AaveV2Payload(IEngine(AaveV2Avalanche.CONFIG_ENGINE)) {}

--- a/src/v2-config-engine/AaveV2PayloadEthereum.sol
+++ b/src/v2-config-engine/AaveV2PayloadEthereum.sol
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {AaveV2Ethereum} from 'aave-address-book/AaveV2Ethereum.sol';
-import './AaveV2Payload.sol';
+import {AaveV2Ethereum} from "aave-address-book/AaveV2Ethereum.sol";
+import "./AaveV2Payload.sol";
 
 /**
  * @dev Base smart contract for an Aave v2 rates update on Ethereum.
  * @author BGD Labs
  */
 // TODO: Add rates factory address after deploying
-abstract contract AaveV2PayloadEthereum is AaveV2Payload(IEngine(AaveV2Ethereum.CONFIG_ENGINE)) {
-
-}
+abstract contract AaveV2PayloadEthereum is AaveV2Payload(IEngine(AaveV2Ethereum.CONFIG_ENGINE)) {}

--- a/src/v2-config-engine/AaveV2PayloadEthereumAMM.sol
+++ b/src/v2-config-engine/AaveV2PayloadEthereumAMM.sol
@@ -1,16 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {AaveV2EthereumAMM} from 'aave-address-book/AaveV2EthereumAMM.sol';
-import './AaveV2Payload.sol';
+import {AaveV2EthereumAMM} from "aave-address-book/AaveV2EthereumAMM.sol";
+import "./AaveV2Payload.sol";
 
 /**
  * @dev Base smart contract for an Aave v2 rates update on Ethereum.
  * @author BGD Labs
  */
 // TODO: Add rates factory address after deploying
-abstract contract AaveV2PayloadEthereumAMM is
-  AaveV2Payload(IEngine(AaveV2EthereumAMM.CONFIG_ENGINE))
-{
-
-}
+abstract contract AaveV2PayloadEthereumAMM is AaveV2Payload(IEngine(AaveV2EthereumAMM.CONFIG_ENGINE)) {}

--- a/src/v2-config-engine/AaveV2PayloadPolygon.sol
+++ b/src/v2-config-engine/AaveV2PayloadPolygon.sol
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {AaveV2Polygon} from 'aave-address-book/AaveV2Polygon.sol';
-import './AaveV2Payload.sol';
+import {AaveV2Polygon} from "aave-address-book/AaveV2Polygon.sol";
+import "./AaveV2Payload.sol";
 
 /**
  * @dev Base smart contract for an Aave v2 rates update on Avalanche.
  * @author BGD Labs
  */
 // TODO: Add rates factory address after deploying
-abstract contract AaveV2PayloadPolygon is AaveV2Payload(IEngine(AaveV2Polygon.CONFIG_ENGINE)) {
-
-}
+abstract contract AaveV2PayloadPolygon is AaveV2Payload(IEngine(AaveV2Polygon.CONFIG_ENGINE)) {}

--- a/src/v2-config-engine/IAaveV2ConfigEngine.sol
+++ b/src/v2-config-engine/IAaveV2ConfigEngine.sol
@@ -1,52 +1,199 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {ILendingPoolConfigurator} from 'aave-address-book/AaveV2.sol';
-import {IV2RateStrategyFactory} from './IV2RateStrategyFactory.sol';
+import {ILendingPool, ILendingPoolConfigurator, IAaveOracle} from "aave-address-book/AaveV2.sol";
+import {IV2RateStrategyFactory} from "./IV2RateStrategyFactory.sol";
 
 /// @dev Examples here assume the usage of the `AaveV2Payload` base contracts
 /// contained in this same repository
 interface IAaveV2ConfigEngine {
-  /**
-   * @dev Example (mock):
-   * PoolContext({
-   *   networkName: 'Polygon',
-   *   networkAbbreviation: 'Pol'
-   * })
-   */
-  struct PoolContext {
-    string networkName;
-    string networkAbbreviation;
-  }
+    struct Basic {
+        string assetSymbol;
+        string assetName;
+        TokenImplementations implementations;
+    }
 
-  /**
-   * @dev Example (mock):
-   * RateStrategyUpdate({
-   *   asset: AaveV2EthereumAssets.AAVE_UNDERLYING,
-   *   params: IV2RateStrategyFactory.RateStrategyParams({
-   *     optimalUtilizationRate: _bpsToRay(80_00),
-   *     baseVariableBorrowRate: EngineFlags.KEEP_CURRENT,
-   *     variableRateSlope1: EngineFlags.KEEP_CURRENT,
-   *     variableRateSlope2: _bpsToRay(75_00),
-   *     stableRateSlope1: EngineFlags.KEEP_CURRENT,
-   *     stableRateSlope2: _bpsToRay(75_00),
-   *   })
-   * })
-   */
-  struct RateStrategyUpdate {
-    address asset;
-    IV2RateStrategyFactory.RateStrategyParams params;
-  }
+    struct EngineLibraries {
+        address listingEngine;
+        address borrowEngine;
+        address collateralEngine;
+        address priceFeedEngine;
+        address rateEngine;
+    }
 
-  /**
-   * @notice Performs an update on the rate strategy params of the assets, in the Aave pool configured in this engine instance
-   * @dev The engine itself manages if a new rate strategy needs to be deployed or if an existing one can be re-used
-   * @param updates `RateStrategyUpdate[]` list of declarative updates containing the new rate strategy params
-   *   More information on the documentation of the struct.
-   */
-  function updateRateStrategies(RateStrategyUpdate[] memory updates) external;
+    struct EngineConstants {
+        ILendingPool pool;
+        ILendingPoolConfigurator poolConfigurator;
+        IV2RateStrategyFactory ratesStrategyFactory;
+        IAaveOracle oracle;
+        address rewardsController;
+        address collector;
+    }
 
-  function RATE_STRATEGIES_FACTORY() external view returns (IV2RateStrategyFactory);
+    /**
+     * @dev Example (mock):
+     * PoolContext({
+     *   networkName: 'Polygon',
+     *   networkAbbreviation: 'Pol'
+     * })
+     */
+    struct PoolContext {
+        string networkName;
+        string networkAbbreviation;
+    }
 
-  function POOL_CONFIGURATOR() external view returns (ILendingPoolConfigurator);
+    /**
+     * @dev Example (mock):
+     * ListingV2({
+     *   asset: 0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9,
+     *   assetSymbol: 'AAVE',
+     *   assetName: 'Aave Token',
+     *   priceFeed: 0x547a514d5e3769680Ce22B2361c10Ea13619e8a9,
+     *   rateStrategyParams: Rates.RateStrategyParams({
+     *     optimalUsageRatio: _bpsToRay(80_00),
+     *     baseVariableBorrowRate: _bpsToRay(25), // 0.25%
+     *     variableRateSlope1: _bpsToRay(3_00),
+     *     variableRateSlope2: _bpsToRay(75_00),
+     *     stableRateSlope1: _bpsToRay(3_00),
+     *     stableRateSlope2: _bpsToRay(75_00)
+     *   }),
+     *   enabledToBorrow: EngineFlags.ENABLED,
+     *   flashloanable: EngineFlags.ENABLED,
+     *   stableRateModeEnabled: EngineFlags.DISABLED,
+     *   ltv: 70_50, // 70.5%
+     *   liqThreshold: 76_00, // 76%
+     *   liqBonus: 5_00, // 5%
+     *   reserveFactor: 10_00, // 10%
+     *   liqProtocolFee: 10_00, // 10%
+     * }
+     */
+    struct ListingV2 {
+        address asset;
+        string assetSymbol;
+        string assetName;
+        address priceFeed;
+        IV2RateStrategyFactory.RateStrategyParams rateStrategyParams; // Mandatory, no matter if enabled for borrowing or not
+        uint256 enabledToBorrow;
+        uint256 stableRateModeEnabled; // Only considered is enabledToBorrow == EngineFlags.ENABLED (true)
+        uint256 ltv; // Only considered if liqThreshold > 0
+        uint256 liqThreshold; // If `0`, the asset will not be enabled as collateral
+        uint256 liqBonus; // Only considered if liqThreshold > 0
+        uint256 reserveFactor; // Only considered if enabledToBorrow == EngineFlags.ENABLED (true)
+        uint256 liqProtocolFee; // Only considered if liqThreshold > 0
+    }
+
+    struct RepackedListings {
+        address[] ids;
+        Basic[] basics;
+        BorrowUpdate[] borrowsUpdates;
+        CollateralUpdate[] collateralsUpdates;
+        PriceFeedUpdate[] priceFeedsUpdates;
+        IV2RateStrategyFactory.RateStrategyParams[] rates;
+    }
+
+    struct TokenImplementations {
+        address aToken;
+        address vToken;
+        address sToken;
+    }
+
+    struct ListingWithCustomImpl {
+        ListingV2 base;
+        TokenImplementations implementations;
+    }
+
+    /**
+     * @dev Example (mock):
+     * BorrowUpdate({
+     *   asset: AaveV3EthereumAssets.AAVE_UNDERLYING,
+     *   enabledToBorrow: EngineFlags.ENABLED,
+     *   stableRateModeEnabled: EngineFlags.KEEP_CURRENT,
+     *   reserveFactor: 15_00, // 15%
+     * })
+     */
+    struct BorrowUpdate {
+        address asset;
+        uint256 enabledToBorrow;
+        uint256 stableRateModeEnabled;
+        uint256 reserveFactor;
+    }
+
+    /**
+     * @dev Example (mock):
+     * CollateralUpdate({
+     *   asset: AaveV3EthereumAssets.AAVE_UNDERLYING,
+     *   ltv: 60_00,
+     *   liqThreshold: 70_00,
+     *   liqBonus: EngineFlags.KEEP_CURRENT,
+     * })
+     */
+    struct CollateralUpdate {
+        address asset;
+        uint256 ltv;
+        uint256 liqThreshold;
+        uint256 liqBonus;
+    }
+
+    /**
+     * @dev Example (mock):
+     * PriceFeedUpdate({
+     *   asset: AaveV2EthereumAssets.AAVE_UNDERLYING,
+     *   priceFeed: 0x547a514d5e3769680Ce22B2361c10Ea13619e8a9
+     * })
+     */
+    struct PriceFeedUpdate {
+        address asset;
+        address priceFeed;
+    }
+
+    /**
+     * @dev Example (mock):
+     * RateStrategyUpdate({
+     *   asset: AaveV2EthereumAssets.AAVE_UNDERLYING,
+     *   params: IV2RateStrategyFactory.RateStrategyParams({
+     *     optimalUtilizationRate: _bpsToRay(80_00),
+     *     baseVariableBorrowRate: EngineFlags.KEEP_CURRENT,
+     *     variableRateSlope1: EngineFlags.KEEP_CURRENT,
+     *     variableRateSlope2: _bpsToRay(75_00),
+     *     stableRateSlope1: EngineFlags.KEEP_CURRENT,
+     *     stableRateSlope2: _bpsToRay(75_00),
+     *   })
+     * })
+     */
+    struct RateStrategyUpdate {
+        address asset;
+        IV2RateStrategyFactory.RateStrategyParams params;
+    }
+
+    /**
+     * @notice Performs full listing of the assets, in the Aave pool configured in this engine instance
+     * @param context `PoolContext` struct, effectively meta-data for naming of a/v/s tokens.
+     *   More information on the documentation of the struct.
+     * @param listings `Listing[]` list of declarative configs for every aspect of the asset listings.
+     *   More information on the documentation of the struct.
+     */
+    function listAssets(PoolContext memory context, ListingV2[] memory listings) external;
+
+    /**
+     * @notice Performs full listings of assets, in the Aave pool configured in this engine instance
+     * @dev This function allows more customization, especifically enables to set custom implementations
+     *   for a/v/s tokens.
+     *   IMPORTANT. Use it only if understanding the internals of the Aave v2 protocol
+     * @param context `PoolContext` struct, effectively meta-data for naming of a/v/s tokens.
+     *   More information on the documentation of the struct.
+     * @param listings `ListingWithCustomImpl[]` list of declarative configs for every aspect of the asset listings.
+     */
+    function listAssetsCustom(PoolContext memory context, ListingWithCustomImpl[] memory listings) external;
+
+    /**
+     * @notice Performs an update on the rate strategy params of the assets, in the Aave pool configured in this engine instance
+     * @dev The engine itself manages if a new rate strategy needs to be deployed or if an existing one can be re-used
+     * @param updates `RateStrategyUpdate[]` list of declarative updates containing the new rate strategy params
+     *   More information on the documentation of the struct.
+     */
+    function updateRateStrategies(RateStrategyUpdate[] memory updates) external;
+
+    function RATE_STRATEGIES_FACTORY() external view returns (IV2RateStrategyFactory);
+
+    function POOL_CONFIGURATOR() external view returns (ILendingPoolConfigurator);
 }

--- a/src/v2-config-engine/IAaveV2ConfigEngine.sol
+++ b/src/v2-config-engine/IAaveV2ConfigEngine.sol
@@ -196,7 +196,31 @@ interface IAaveV2ConfigEngine {
    */
   function updateRateStrategies(RateStrategyUpdate[] memory updates) external;
 
-  function RATE_STRATEGIES_FACTORY() external view returns (IV2RateStrategyFactory);
+  function RATE_STRATEGY_FACTORY() external view returns (IV2RateStrategyFactory);
+
+  function POOL() external view returns (ILendingPool);
 
   function POOL_CONFIGURATOR() external view returns (ILendingPoolConfigurator);
+
+  function ORACLE() external view returns (IAaveOracle);
+
+  function ATOKEN_IMPL() external view returns (address);
+
+  function VTOKEN_IMPL() external view returns (address);
+
+  function STOKEN_IMPL() external view returns (address);
+
+  function REWARDS_CONTROLLER() external view returns (address);
+
+  function COLLECTOR() external view returns (address);
+
+  function BORROW_ENGINE() external view returns (address);
+
+  function COLLATERAL_ENGINE() external view returns (address);
+
+  function LISTING_ENGINE() external view returns (address);
+
+  function PRICE_FEED_ENGINE() external view returns (address);
+
+  function RATE_ENGINE() external view returns (address);
 }

--- a/src/v2-config-engine/IAaveV2ConfigEngine.sol
+++ b/src/v2-config-engine/IAaveV2ConfigEngine.sol
@@ -196,6 +196,27 @@ interface IAaveV2ConfigEngine {
    */
   function updateRateStrategies(RateStrategyUpdate[] memory updates) external;
 
+  /**
+   * @notice Performs an update of the collateral-related params of the assets, in the Aave pool configured in this engine instance
+   * @param updates `CollateralUpdate[]` list of declarative updates containing the new parameters
+   *   More information on the documentation of the struct.
+   */
+  function updateCollateralSide(CollateralUpdate[] memory updates) external;
+
+  /**
+   * @notice Performs an update of the price feed of the assets, in the Aave pool configured in this engine instance
+   * @param updates `PriceFeedUpdate[]` list of declarative updates containing the new parameters
+   *   More information on the documentation of the struct.
+   */
+  function updatePriceFeeds(PriceFeedUpdate[] memory updates) external;
+
+  /**
+   * @notice Performs an update of the borrow-related params of the assets, in the Aave pool configured in this engine instance
+   * @param updates `BorrowUpdate[]` list of declarative updates containing the new parameters
+   *   More information on the documentation of the struct.
+   */
+  function updateBorrowSide(BorrowUpdate[] memory updates) external;
+
   function RATE_STRATEGY_FACTORY() external view returns (IV2RateStrategyFactory);
 
   function POOL() external view returns (ILendingPool);

--- a/src/v2-config-engine/IAaveV2ConfigEngine.sol
+++ b/src/v2-config-engine/IAaveV2ConfigEngine.sol
@@ -1,199 +1,202 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {ILendingPool, ILendingPoolConfigurator, IAaveOracle} from "aave-address-book/AaveV2.sol";
-import {IV2RateStrategyFactory} from "./IV2RateStrategyFactory.sol";
+import {ILendingPool, ILendingPoolConfigurator, IAaveOracle} from 'aave-address-book/AaveV2.sol';
+import {IV2RateStrategyFactory} from './IV2RateStrategyFactory.sol';
 
 /// @dev Examples here assume the usage of the `AaveV2Payload` base contracts
 /// contained in this same repository
 interface IAaveV2ConfigEngine {
-    struct Basic {
-        string assetSymbol;
-        string assetName;
-        TokenImplementations implementations;
-    }
+  struct Basic {
+    string assetSymbol;
+    string assetName;
+    TokenImplementations implementations;
+  }
 
-    struct EngineLibraries {
-        address listingEngine;
-        address borrowEngine;
-        address collateralEngine;
-        address priceFeedEngine;
-        address rateEngine;
-    }
+  struct EngineLibraries {
+    address listingEngine;
+    address borrowEngine;
+    address collateralEngine;
+    address priceFeedEngine;
+    address rateEngine;
+  }
 
-    struct EngineConstants {
-        ILendingPool pool;
-        ILendingPoolConfigurator poolConfigurator;
-        IV2RateStrategyFactory ratesStrategyFactory;
-        IAaveOracle oracle;
-        address rewardsController;
-        address collector;
-    }
+  struct EngineConstants {
+    ILendingPool pool;
+    ILendingPoolConfigurator poolConfigurator;
+    IV2RateStrategyFactory ratesStrategyFactory;
+    IAaveOracle oracle;
+    address rewardsController;
+    address collector;
+  }
 
-    /**
-     * @dev Example (mock):
-     * PoolContext({
-     *   networkName: 'Polygon',
-     *   networkAbbreviation: 'Pol'
-     * })
-     */
-    struct PoolContext {
-        string networkName;
-        string networkAbbreviation;
-    }
+  /**
+   * @dev Example (mock):
+   * PoolContext({
+   *   networkName: 'Polygon',
+   *   networkAbbreviation: 'Pol'
+   * })
+   */
+  struct PoolContext {
+    string networkName;
+    string networkAbbreviation;
+  }
 
-    /**
-     * @dev Example (mock):
-     * ListingV2({
-     *   asset: 0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9,
-     *   assetSymbol: 'AAVE',
-     *   assetName: 'Aave Token',
-     *   priceFeed: 0x547a514d5e3769680Ce22B2361c10Ea13619e8a9,
-     *   rateStrategyParams: Rates.RateStrategyParams({
-     *     optimalUsageRatio: _bpsToRay(80_00),
-     *     baseVariableBorrowRate: _bpsToRay(25), // 0.25%
-     *     variableRateSlope1: _bpsToRay(3_00),
-     *     variableRateSlope2: _bpsToRay(75_00),
-     *     stableRateSlope1: _bpsToRay(3_00),
-     *     stableRateSlope2: _bpsToRay(75_00)
-     *   }),
-     *   enabledToBorrow: EngineFlags.ENABLED,
-     *   flashloanable: EngineFlags.ENABLED,
-     *   stableRateModeEnabled: EngineFlags.DISABLED,
-     *   ltv: 70_50, // 70.5%
-     *   liqThreshold: 76_00, // 76%
-     *   liqBonus: 5_00, // 5%
-     *   reserveFactor: 10_00, // 10%
-     *   liqProtocolFee: 10_00, // 10%
-     * }
-     */
-    struct ListingV2 {
-        address asset;
-        string assetSymbol;
-        string assetName;
-        address priceFeed;
-        IV2RateStrategyFactory.RateStrategyParams rateStrategyParams; // Mandatory, no matter if enabled for borrowing or not
-        uint256 enabledToBorrow;
-        uint256 stableRateModeEnabled; // Only considered is enabledToBorrow == EngineFlags.ENABLED (true)
-        uint256 ltv; // Only considered if liqThreshold > 0
-        uint256 liqThreshold; // If `0`, the asset will not be enabled as collateral
-        uint256 liqBonus; // Only considered if liqThreshold > 0
-        uint256 reserveFactor; // Only considered if enabledToBorrow == EngineFlags.ENABLED (true)
-        uint256 liqProtocolFee; // Only considered if liqThreshold > 0
-    }
+  /**
+   * @dev Example (mock):
+   * ListingV2({
+   *   asset: 0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9,
+   *   assetSymbol: 'AAVE',
+   *   assetName: 'Aave Token',
+   *   priceFeed: 0x547a514d5e3769680Ce22B2361c10Ea13619e8a9,
+   *   rateStrategyParams: Rates.RateStrategyParams({
+   *     optimalUsageRatio: _bpsToRay(80_00),
+   *     baseVariableBorrowRate: _bpsToRay(25), // 0.25%
+   *     variableRateSlope1: _bpsToRay(3_00),
+   *     variableRateSlope2: _bpsToRay(75_00),
+   *     stableRateSlope1: _bpsToRay(3_00),
+   *     stableRateSlope2: _bpsToRay(75_00)
+   *   }),
+   *   enabledToBorrow: EngineFlags.ENABLED,
+   *   flashloanable: EngineFlags.ENABLED,
+   *   stableRateModeEnabled: EngineFlags.DISABLED,
+   *   ltv: 70_50, // 70.5%
+   *   liqThreshold: 76_00, // 76%
+   *   liqBonus: 5_00, // 5%
+   *   reserveFactor: 10_00, // 10%
+   *   liqProtocolFee: 10_00, // 10%
+   * }
+   */
+  struct ListingV2 {
+    address asset;
+    string assetSymbol;
+    string assetName;
+    address priceFeed;
+    IV2RateStrategyFactory.RateStrategyParams rateStrategyParams; // Mandatory, no matter if enabled for borrowing or not
+    uint256 enabledToBorrow;
+    uint256 stableRateModeEnabled; // Only considered is enabledToBorrow == EngineFlags.ENABLED (true)
+    uint256 ltv; // Only considered if liqThreshold > 0
+    uint256 liqThreshold; // If `0`, the asset will not be enabled as collateral
+    uint256 liqBonus; // Only considered if liqThreshold > 0
+    uint256 reserveFactor; // Only considered if enabledToBorrow == EngineFlags.ENABLED (true)
+    uint256 liqProtocolFee; // Only considered if liqThreshold > 0
+  }
 
-    struct RepackedListings {
-        address[] ids;
-        Basic[] basics;
-        BorrowUpdate[] borrowsUpdates;
-        CollateralUpdate[] collateralsUpdates;
-        PriceFeedUpdate[] priceFeedsUpdates;
-        IV2RateStrategyFactory.RateStrategyParams[] rates;
-    }
+  struct RepackedListings {
+    address[] ids;
+    Basic[] basics;
+    BorrowUpdate[] borrowsUpdates;
+    CollateralUpdate[] collateralsUpdates;
+    PriceFeedUpdate[] priceFeedsUpdates;
+    IV2RateStrategyFactory.RateStrategyParams[] rates;
+  }
 
-    struct TokenImplementations {
-        address aToken;
-        address vToken;
-        address sToken;
-    }
+  struct TokenImplementations {
+    address aToken;
+    address vToken;
+    address sToken;
+  }
 
-    struct ListingWithCustomImpl {
-        ListingV2 base;
-        TokenImplementations implementations;
-    }
+  struct ListingWithCustomImpl {
+    ListingV2 base;
+    TokenImplementations implementations;
+  }
 
-    /**
-     * @dev Example (mock):
-     * BorrowUpdate({
-     *   asset: AaveV3EthereumAssets.AAVE_UNDERLYING,
-     *   enabledToBorrow: EngineFlags.ENABLED,
-     *   stableRateModeEnabled: EngineFlags.KEEP_CURRENT,
-     *   reserveFactor: 15_00, // 15%
-     * })
-     */
-    struct BorrowUpdate {
-        address asset;
-        uint256 enabledToBorrow;
-        uint256 stableRateModeEnabled;
-        uint256 reserveFactor;
-    }
+  /**
+   * @dev Example (mock):
+   * BorrowUpdate({
+   *   asset: AaveV3EthereumAssets.AAVE_UNDERLYING,
+   *   enabledToBorrow: EngineFlags.ENABLED,
+   *   stableRateModeEnabled: EngineFlags.KEEP_CURRENT,
+   *   reserveFactor: 15_00, // 15%
+   * })
+   */
+  struct BorrowUpdate {
+    address asset;
+    uint256 enabledToBorrow;
+    uint256 stableRateModeEnabled;
+    uint256 reserveFactor;
+  }
 
-    /**
-     * @dev Example (mock):
-     * CollateralUpdate({
-     *   asset: AaveV3EthereumAssets.AAVE_UNDERLYING,
-     *   ltv: 60_00,
-     *   liqThreshold: 70_00,
-     *   liqBonus: EngineFlags.KEEP_CURRENT,
-     * })
-     */
-    struct CollateralUpdate {
-        address asset;
-        uint256 ltv;
-        uint256 liqThreshold;
-        uint256 liqBonus;
-    }
+  /**
+   * @dev Example (mock):
+   * CollateralUpdate({
+   *   asset: AaveV3EthereumAssets.AAVE_UNDERLYING,
+   *   ltv: 60_00,
+   *   liqThreshold: 70_00,
+   *   liqBonus: EngineFlags.KEEP_CURRENT,
+   * })
+   */
+  struct CollateralUpdate {
+    address asset;
+    uint256 ltv;
+    uint256 liqThreshold;
+    uint256 liqBonus;
+  }
 
-    /**
-     * @dev Example (mock):
-     * PriceFeedUpdate({
-     *   asset: AaveV2EthereumAssets.AAVE_UNDERLYING,
-     *   priceFeed: 0x547a514d5e3769680Ce22B2361c10Ea13619e8a9
-     * })
-     */
-    struct PriceFeedUpdate {
-        address asset;
-        address priceFeed;
-    }
+  /**
+   * @dev Example (mock):
+   * PriceFeedUpdate({
+   *   asset: AaveV2EthereumAssets.AAVE_UNDERLYING,
+   *   priceFeed: 0x547a514d5e3769680Ce22B2361c10Ea13619e8a9
+   * })
+   */
+  struct PriceFeedUpdate {
+    address asset;
+    address priceFeed;
+  }
 
-    /**
-     * @dev Example (mock):
-     * RateStrategyUpdate({
-     *   asset: AaveV2EthereumAssets.AAVE_UNDERLYING,
-     *   params: IV2RateStrategyFactory.RateStrategyParams({
-     *     optimalUtilizationRate: _bpsToRay(80_00),
-     *     baseVariableBorrowRate: EngineFlags.KEEP_CURRENT,
-     *     variableRateSlope1: EngineFlags.KEEP_CURRENT,
-     *     variableRateSlope2: _bpsToRay(75_00),
-     *     stableRateSlope1: EngineFlags.KEEP_CURRENT,
-     *     stableRateSlope2: _bpsToRay(75_00),
-     *   })
-     * })
-     */
-    struct RateStrategyUpdate {
-        address asset;
-        IV2RateStrategyFactory.RateStrategyParams params;
-    }
+  /**
+   * @dev Example (mock):
+   * RateStrategyUpdate({
+   *   asset: AaveV2EthereumAssets.AAVE_UNDERLYING,
+   *   params: IV2RateStrategyFactory.RateStrategyParams({
+   *     optimalUtilizationRate: _bpsToRay(80_00),
+   *     baseVariableBorrowRate: EngineFlags.KEEP_CURRENT,
+   *     variableRateSlope1: EngineFlags.KEEP_CURRENT,
+   *     variableRateSlope2: _bpsToRay(75_00),
+   *     stableRateSlope1: EngineFlags.KEEP_CURRENT,
+   *     stableRateSlope2: _bpsToRay(75_00),
+   *   })
+   * })
+   */
+  struct RateStrategyUpdate {
+    address asset;
+    IV2RateStrategyFactory.RateStrategyParams params;
+  }
 
-    /**
-     * @notice Performs full listing of the assets, in the Aave pool configured in this engine instance
-     * @param context `PoolContext` struct, effectively meta-data for naming of a/v/s tokens.
-     *   More information on the documentation of the struct.
-     * @param listings `Listing[]` list of declarative configs for every aspect of the asset listings.
-     *   More information on the documentation of the struct.
-     */
-    function listAssets(PoolContext memory context, ListingV2[] memory listings) external;
+  /**
+   * @notice Performs full listing of the assets, in the Aave pool configured in this engine instance
+   * @param context `PoolContext` struct, effectively meta-data for naming of a/v/s tokens.
+   *   More information on the documentation of the struct.
+   * @param listings `Listing[]` list of declarative configs for every aspect of the asset listings.
+   *   More information on the documentation of the struct.
+   */
+  function listAssets(PoolContext memory context, ListingV2[] memory listings) external;
 
-    /**
-     * @notice Performs full listings of assets, in the Aave pool configured in this engine instance
-     * @dev This function allows more customization, especifically enables to set custom implementations
-     *   for a/v/s tokens.
-     *   IMPORTANT. Use it only if understanding the internals of the Aave v2 protocol
-     * @param context `PoolContext` struct, effectively meta-data for naming of a/v/s tokens.
-     *   More information on the documentation of the struct.
-     * @param listings `ListingWithCustomImpl[]` list of declarative configs for every aspect of the asset listings.
-     */
-    function listAssetsCustom(PoolContext memory context, ListingWithCustomImpl[] memory listings) external;
+  /**
+   * @notice Performs full listings of assets, in the Aave pool configured in this engine instance
+   * @dev This function allows more customization, especifically enables to set custom implementations
+   *   for a/v/s tokens.
+   *   IMPORTANT. Use it only if understanding the internals of the Aave v2 protocol
+   * @param context `PoolContext` struct, effectively meta-data for naming of a/v/s tokens.
+   *   More information on the documentation of the struct.
+   * @param listings `ListingWithCustomImpl[]` list of declarative configs for every aspect of the asset listings.
+   */
+  function listAssetsCustom(
+    PoolContext memory context,
+    ListingWithCustomImpl[] memory listings
+  ) external;
 
-    /**
-     * @notice Performs an update on the rate strategy params of the assets, in the Aave pool configured in this engine instance
-     * @dev The engine itself manages if a new rate strategy needs to be deployed or if an existing one can be re-used
-     * @param updates `RateStrategyUpdate[]` list of declarative updates containing the new rate strategy params
-     *   More information on the documentation of the struct.
-     */
-    function updateRateStrategies(RateStrategyUpdate[] memory updates) external;
+  /**
+   * @notice Performs an update on the rate strategy params of the assets, in the Aave pool configured in this engine instance
+   * @dev The engine itself manages if a new rate strategy needs to be deployed or if an existing one can be re-used
+   * @param updates `RateStrategyUpdate[]` list of declarative updates containing the new rate strategy params
+   *   More information on the documentation of the struct.
+   */
+  function updateRateStrategies(RateStrategyUpdate[] memory updates) external;
 
-    function RATE_STRATEGIES_FACTORY() external view returns (IV2RateStrategyFactory);
+  function RATE_STRATEGIES_FACTORY() external view returns (IV2RateStrategyFactory);
 
-    function POOL_CONFIGURATOR() external view returns (ILendingPoolConfigurator);
+  function POOL_CONFIGURATOR() external view returns (ILendingPoolConfigurator);
 }

--- a/src/v2-config-engine/IV2RateStrategyFactory.sol
+++ b/src/v2-config-engine/IV2RateStrategyFactory.sol
@@ -1,72 +1,66 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {IDefaultInterestRateStrategy, ILendingPoolAddressesProvider} from 'aave-address-book/AaveV2.sol';
+import {IDefaultInterestRateStrategy, ILendingPoolAddressesProvider} from "aave-address-book/AaveV2.sol";
 
 interface IV2RateStrategyFactory {
-  event RateStrategyCreated(
-    address indexed strategy,
-    bytes32 indexed hashedParam,
-    RateStrategyParams params
-  );
+    event RateStrategyCreated(address indexed strategy, bytes32 indexed hashedParam, RateStrategyParams params);
 
-  /// @dev same parameters and the ones received on the constructor of DefaultReserveInterestRateStrategy
-  /// in practise defining the strategy itself
-  struct RateStrategyParams {
-    uint256 optimalUtilizationRate;
-    uint256 baseVariableBorrowRate;
-    uint256 variableRateSlope1;
-    uint256 variableRateSlope2;
-    uint256 stableRateSlope1;
-    uint256 stableRateSlope2;
-  }
+    /// @dev same parameters and the ones received on the constructor of DefaultReserveInterestRateStrategy
+    /// in practise defining the strategy itself
+    struct RateStrategyParams {
+        uint256 optimalUtilizationRate;
+        uint256 baseVariableBorrowRate;
+        uint256 variableRateSlope1;
+        uint256 variableRateSlope2;
+        uint256 stableRateSlope1;
+        uint256 stableRateSlope2;
+    }
 
-  /**
-   * @notice Create new rate strategies from a list of parameters
-   * @dev If a strategy with exactly the same `RateStrategyParams` already exists, no creation happens but
-   *  its address is returned
-   * @param params `RateStrategyParams[]` list of parameters for multiple strategies
-   * @return address[] list of strategies
-   */
-  function createStrategies(RateStrategyParams[] memory params) external returns (address[] memory);
+    /**
+     * @notice Create new rate strategies from a list of parameters
+     * @dev If a strategy with exactly the same `RateStrategyParams` already exists, no creation happens but
+     *  its address is returned
+     * @param params `RateStrategyParams[]` list of parameters for multiple strategies
+     * @return address[] list of strategies
+     */
+    function createStrategies(RateStrategyParams[] memory params) external returns (address[] memory);
 
-  /**
-   * @notice Returns the identifier of a rate strategy from its parameters
-   * @param params `RateStrategyParams` the parameters of the rate strategy
-   * @return bytes32 the keccak256 hash generated from the `RateStrategyParams` parameters
-   *   to be used as identifier of the rate strategy on the factory
-   */
-  function strategyHashFromParams(RateStrategyParams memory params) external pure returns (bytes32);
+    /**
+     * @notice Returns the identifier of a rate strategy from its parameters
+     * @param params `RateStrategyParams` the parameters of the rate strategy
+     * @return bytes32 the keccak256 hash generated from the `RateStrategyParams` parameters
+     *   to be used as identifier of the rate strategy on the factory
+     */
+    function strategyHashFromParams(RateStrategyParams memory params) external pure returns (bytes32);
 
-  /**
-   * @notice Returns all the strategies registered in the factory
-   * @return address[] list of strategies
-   */
-  function getAllStrategies() external view returns (address[] memory);
+    /**
+     * @notice Returns all the strategies registered in the factory
+     * @return address[] list of strategies
+     */
+    function getAllStrategies() external view returns (address[] memory);
 
-  /**
-   * @notice Returns the a strategy added, given its parameters.
-   * @dev Only if the strategy is registered in the factory.
-   * @param params `RateStrategyParams` the parameters of the rate strategy
-   * @return address the address of the strategy
-   */
-  function getStrategyByParams(RateStrategyParams memory params) external view returns (address);
+    /**
+     * @notice Returns the a strategy added, given its parameters.
+     * @dev Only if the strategy is registered in the factory.
+     * @param params `RateStrategyParams` the parameters of the rate strategy
+     * @return address the address of the strategy
+     */
+    function getStrategyByParams(RateStrategyParams memory params) external view returns (address);
 
-  /**
-   * @notice From an asset in the Aave v3 pool, returns exclusively its parameters
-   * @param asset The address of the asset
-   * @return RateStrategyParams The parameters or the strategy, or empty RateStrategyParams struct
-   */
-  function getStrategyDataOfAsset(address asset) external view returns (RateStrategyParams memory);
+    /**
+     * @notice From an asset in the Aave v3 pool, returns exclusively its parameters
+     * @param asset The address of the asset
+     * @return RateStrategyParams The parameters or the strategy, or empty RateStrategyParams struct
+     */
+    function getStrategyDataOfAsset(address asset) external view returns (RateStrategyParams memory);
 
-  /**
-   * @notice From a rate strategy address, returns its parameters
-   * @param strategy The address of the rate strategy
-   * @return RateStrategyParams Struct with the parameters of the strategy
-   */
-  function getStrategyData(
-    IDefaultInterestRateStrategy strategy
-  ) external view returns (RateStrategyParams memory);
+    /**
+     * @notice From a rate strategy address, returns its parameters
+     * @param strategy The address of the rate strategy
+     * @return RateStrategyParams Struct with the parameters of the strategy
+     */
+    function getStrategyData(IDefaultInterestRateStrategy strategy) external view returns (RateStrategyParams memory);
 
-  function ADDRESSES_PROVIDER() external view returns (ILendingPoolAddressesProvider);
+    function ADDRESSES_PROVIDER() external view returns (ILendingPoolAddressesProvider);
 }

--- a/src/v2-config-engine/IV2RateStrategyFactory.sol
+++ b/src/v2-config-engine/IV2RateStrategyFactory.sol
@@ -1,66 +1,72 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {IDefaultInterestRateStrategy, ILendingPoolAddressesProvider} from "aave-address-book/AaveV2.sol";
+import {IDefaultInterestRateStrategy, ILendingPoolAddressesProvider} from 'aave-address-book/AaveV2.sol';
 
 interface IV2RateStrategyFactory {
-    event RateStrategyCreated(address indexed strategy, bytes32 indexed hashedParam, RateStrategyParams params);
+  event RateStrategyCreated(
+    address indexed strategy,
+    bytes32 indexed hashedParam,
+    RateStrategyParams params
+  );
 
-    /// @dev same parameters and the ones received on the constructor of DefaultReserveInterestRateStrategy
-    /// in practise defining the strategy itself
-    struct RateStrategyParams {
-        uint256 optimalUtilizationRate;
-        uint256 baseVariableBorrowRate;
-        uint256 variableRateSlope1;
-        uint256 variableRateSlope2;
-        uint256 stableRateSlope1;
-        uint256 stableRateSlope2;
-    }
+  /// @dev same parameters and the ones received on the constructor of DefaultReserveInterestRateStrategy
+  /// in practise defining the strategy itself
+  struct RateStrategyParams {
+    uint256 optimalUtilizationRate;
+    uint256 baseVariableBorrowRate;
+    uint256 variableRateSlope1;
+    uint256 variableRateSlope2;
+    uint256 stableRateSlope1;
+    uint256 stableRateSlope2;
+  }
 
-    /**
-     * @notice Create new rate strategies from a list of parameters
-     * @dev If a strategy with exactly the same `RateStrategyParams` already exists, no creation happens but
-     *  its address is returned
-     * @param params `RateStrategyParams[]` list of parameters for multiple strategies
-     * @return address[] list of strategies
-     */
-    function createStrategies(RateStrategyParams[] memory params) external returns (address[] memory);
+  /**
+   * @notice Create new rate strategies from a list of parameters
+   * @dev If a strategy with exactly the same `RateStrategyParams` already exists, no creation happens but
+   *  its address is returned
+   * @param params `RateStrategyParams[]` list of parameters for multiple strategies
+   * @return address[] list of strategies
+   */
+  function createStrategies(RateStrategyParams[] memory params) external returns (address[] memory);
 
-    /**
-     * @notice Returns the identifier of a rate strategy from its parameters
-     * @param params `RateStrategyParams` the parameters of the rate strategy
-     * @return bytes32 the keccak256 hash generated from the `RateStrategyParams` parameters
-     *   to be used as identifier of the rate strategy on the factory
-     */
-    function strategyHashFromParams(RateStrategyParams memory params) external pure returns (bytes32);
+  /**
+   * @notice Returns the identifier of a rate strategy from its parameters
+   * @param params `RateStrategyParams` the parameters of the rate strategy
+   * @return bytes32 the keccak256 hash generated from the `RateStrategyParams` parameters
+   *   to be used as identifier of the rate strategy on the factory
+   */
+  function strategyHashFromParams(RateStrategyParams memory params) external pure returns (bytes32);
 
-    /**
-     * @notice Returns all the strategies registered in the factory
-     * @return address[] list of strategies
-     */
-    function getAllStrategies() external view returns (address[] memory);
+  /**
+   * @notice Returns all the strategies registered in the factory
+   * @return address[] list of strategies
+   */
+  function getAllStrategies() external view returns (address[] memory);
 
-    /**
-     * @notice Returns the a strategy added, given its parameters.
-     * @dev Only if the strategy is registered in the factory.
-     * @param params `RateStrategyParams` the parameters of the rate strategy
-     * @return address the address of the strategy
-     */
-    function getStrategyByParams(RateStrategyParams memory params) external view returns (address);
+  /**
+   * @notice Returns the a strategy added, given its parameters.
+   * @dev Only if the strategy is registered in the factory.
+   * @param params `RateStrategyParams` the parameters of the rate strategy
+   * @return address the address of the strategy
+   */
+  function getStrategyByParams(RateStrategyParams memory params) external view returns (address);
 
-    /**
-     * @notice From an asset in the Aave v3 pool, returns exclusively its parameters
-     * @param asset The address of the asset
-     * @return RateStrategyParams The parameters or the strategy, or empty RateStrategyParams struct
-     */
-    function getStrategyDataOfAsset(address asset) external view returns (RateStrategyParams memory);
+  /**
+   * @notice From an asset in the Aave v3 pool, returns exclusively its parameters
+   * @param asset The address of the asset
+   * @return RateStrategyParams The parameters or the strategy, or empty RateStrategyParams struct
+   */
+  function getStrategyDataOfAsset(address asset) external view returns (RateStrategyParams memory);
 
-    /**
-     * @notice From a rate strategy address, returns its parameters
-     * @param strategy The address of the rate strategy
-     * @return RateStrategyParams Struct with the parameters of the strategy
-     */
-    function getStrategyData(IDefaultInterestRateStrategy strategy) external view returns (RateStrategyParams memory);
+  /**
+   * @notice From a rate strategy address, returns its parameters
+   * @param strategy The address of the rate strategy
+   * @return RateStrategyParams Struct with the parameters of the strategy
+   */
+  function getStrategyData(
+    IDefaultInterestRateStrategy strategy
+  ) external view returns (RateStrategyParams memory);
 
-    function ADDRESSES_PROVIDER() external view returns (ILendingPoolAddressesProvider);
+  function ADDRESSES_PROVIDER() external view returns (ILendingPoolAddressesProvider);
 }

--- a/src/v2-config-engine/V2RateStrategyFactory.sol
+++ b/src/v2-config-engine/V2RateStrategyFactory.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {ILendingPool} from 'aave-address-book/AaveV2.sol';
-import {Initializable} from 'solidity-utils/contracts/transparent-proxy/Initializable.sol';
-import {IV2RateStrategyFactory} from './IV2RateStrategyFactory.sol';
-import {DefaultReserveInterestRateStrategy} from '../dependencies/DefaultReserveInterestRateStrategy.sol';
-import {IDefaultInterestRateStrategy, ILendingPoolAddressesProvider} from 'aave-address-book/AaveV2.sol';
+import {ILendingPool} from "aave-address-book/AaveV2.sol";
+import {Initializable} from "solidity-utils/contracts/transparent-proxy/Initializable.sol";
+import {IV2RateStrategyFactory} from "./IV2RateStrategyFactory.sol";
+import {DefaultReserveInterestRateStrategy} from "../dependencies/DefaultReserveInterestRateStrategy.sol";
+import {IDefaultInterestRateStrategy, ILendingPoolAddressesProvider} from "aave-address-book/AaveV2.sol";
 
 /**
  * @title V2RateStrategyFactory
@@ -14,116 +14,110 @@ import {IDefaultInterestRateStrategy, ILendingPoolAddressesProvider} from 'aave-
  * @author BGD labs
  */
 contract V2RateStrategyFactory is Initializable, IV2RateStrategyFactory {
-  ILendingPoolAddressesProvider public immutable ADDRESSES_PROVIDER;
+    ILendingPoolAddressesProvider public immutable ADDRESSES_PROVIDER;
 
-  mapping(bytes32 => address) internal _strategyByParamsHash;
-  address[] internal _strategies;
+    mapping(bytes32 => address) internal _strategyByParamsHash;
+    address[] internal _strategies;
 
-  constructor(ILendingPoolAddressesProvider addressesProvider) Initializable() {
-    ADDRESSES_PROVIDER = addressesProvider;
-  }
-
-  /// @dev Passing a arbitrary list of rate strategies to be registered as if they would have been deployed
-  /// from this factory, as they share exactly the same code
-  function initialize(IDefaultInterestRateStrategy[] memory liveStrategies) external initializer {
-    for (uint256 i = 0; i < liveStrategies.length; i++) {
-      RateStrategyParams memory params = getStrategyData(liveStrategies[i]);
-
-      bytes32 hashedParams = strategyHashFromParams(params);
-
-      _strategyByParamsHash[hashedParams] = address(liveStrategies[i]);
-      _strategies.push(address(liveStrategies[i]));
-
-      emit RateStrategyCreated(address(liveStrategies[i]), hashedParams, params);
+    constructor(ILendingPoolAddressesProvider addressesProvider) Initializable() {
+        ADDRESSES_PROVIDER = addressesProvider;
     }
-  }
 
-  ///@inheritdoc IV2RateStrategyFactory
-  function createStrategies(RateStrategyParams[] memory params) public returns (address[] memory) {
-    address[] memory strategies = new address[](params.length);
-    for (uint256 i = 0; i < params.length; i++) {
-      bytes32 strategyHashedParams = strategyHashFromParams(params[i]);
+    /// @dev Passing a arbitrary list of rate strategies to be registered as if they would have been deployed
+    /// from this factory, as they share exactly the same code
+    function initialize(IDefaultInterestRateStrategy[] memory liveStrategies) external initializer {
+        for (uint256 i = 0; i < liveStrategies.length; i++) {
+            RateStrategyParams memory params = getStrategyData(liveStrategies[i]);
 
-      address cachedStrategy = _strategyByParamsHash[strategyHashedParams];
+            bytes32 hashedParams = strategyHashFromParams(params);
 
-      if (cachedStrategy == address(0)) {
-        cachedStrategy = address(
-          new DefaultReserveInterestRateStrategy(
-            ADDRESSES_PROVIDER,
-            params[i].optimalUtilizationRate,
-            params[i].baseVariableBorrowRate,
-            params[i].variableRateSlope1,
-            params[i].variableRateSlope2,
-            params[i].stableRateSlope1,
-            params[i].stableRateSlope2
-          )
+            _strategyByParamsHash[hashedParams] = address(liveStrategies[i]);
+            _strategies.push(address(liveStrategies[i]));
+
+            emit RateStrategyCreated(address(liveStrategies[i]), hashedParams, params);
+        }
+    }
+
+    ///@inheritdoc IV2RateStrategyFactory
+    function createStrategies(RateStrategyParams[] memory params) public returns (address[] memory) {
+        address[] memory strategies = new address[](params.length);
+        for (uint256 i = 0; i < params.length; i++) {
+            bytes32 strategyHashedParams = strategyHashFromParams(params[i]);
+
+            address cachedStrategy = _strategyByParamsHash[strategyHashedParams];
+
+            if (cachedStrategy == address(0)) {
+                cachedStrategy = address(
+                    new DefaultReserveInterestRateStrategy(
+                        ADDRESSES_PROVIDER,
+                        params[i].optimalUtilizationRate,
+                        params[i].baseVariableBorrowRate,
+                        params[i].variableRateSlope1,
+                        params[i].variableRateSlope2,
+                        params[i].stableRateSlope1,
+                        params[i].stableRateSlope2
+                    )
+                );
+                _strategyByParamsHash[strategyHashedParams] = cachedStrategy;
+                _strategies.push(cachedStrategy);
+
+                emit RateStrategyCreated(cachedStrategy, strategyHashedParams, params[i]);
+            }
+
+            strategies[i] = cachedStrategy;
+        }
+
+        return strategies;
+    }
+
+    ///@inheritdoc IV2RateStrategyFactory
+    function strategyHashFromParams(RateStrategyParams memory params) public pure returns (bytes32) {
+        return keccak256(
+            abi.encodePacked(
+                params.optimalUtilizationRate,
+                params.baseVariableBorrowRate,
+                params.variableRateSlope1,
+                params.variableRateSlope2,
+                params.stableRateSlope1,
+                params.stableRateSlope2
+            )
         );
-        _strategyByParamsHash[strategyHashedParams] = cachedStrategy;
-        _strategies.push(cachedStrategy);
-
-        emit RateStrategyCreated(cachedStrategy, strategyHashedParams, params[i]);
-      }
-
-      strategies[i] = cachedStrategy;
     }
 
-    return strategies;
-  }
-
-  ///@inheritdoc IV2RateStrategyFactory
-  function strategyHashFromParams(RateStrategyParams memory params) public pure returns (bytes32) {
-    return
-      keccak256(
-        abi.encodePacked(
-          params.optimalUtilizationRate,
-          params.baseVariableBorrowRate,
-          params.variableRateSlope1,
-          params.variableRateSlope2,
-          params.stableRateSlope1,
-          params.stableRateSlope2
-        )
-      );
-  }
-
-  ///@inheritdoc IV2RateStrategyFactory
-  function getAllStrategies() external view returns (address[] memory) {
-    return _strategies;
-  }
-
-  ///@inheritdoc IV2RateStrategyFactory
-  function getStrategyByParams(RateStrategyParams memory params) external view returns (address) {
-    return _strategyByParamsHash[strategyHashFromParams(params)];
-  }
-
-  ///@inheritdoc IV2RateStrategyFactory
-  function getStrategyDataOfAsset(address asset) external view returns (RateStrategyParams memory) {
-    RateStrategyParams memory params;
-
-    IDefaultInterestRateStrategy strategy = IDefaultInterestRateStrategy(
-      ILendingPool(ADDRESSES_PROVIDER.getLendingPool())
-        .getReserveData(asset)
-        .interestRateStrategyAddress
-    );
-
-    if (address(strategy) != address(0)) {
-      params = getStrategyData(strategy);
+    ///@inheritdoc IV2RateStrategyFactory
+    function getAllStrategies() external view returns (address[] memory) {
+        return _strategies;
     }
 
-    return params;
-  }
+    ///@inheritdoc IV2RateStrategyFactory
+    function getStrategyByParams(RateStrategyParams memory params) external view returns (address) {
+        return _strategyByParamsHash[strategyHashFromParams(params)];
+    }
 
-  ///@inheritdoc IV2RateStrategyFactory
-  function getStrategyData(
-    IDefaultInterestRateStrategy strategy
-  ) public view returns (RateStrategyParams memory) {
-    return
-      RateStrategyParams({
-        optimalUtilizationRate: strategy.OPTIMAL_UTILIZATION_RATE(),
-        baseVariableBorrowRate: strategy.baseVariableBorrowRate(),
-        variableRateSlope1: strategy.variableRateSlope1(),
-        variableRateSlope2: strategy.variableRateSlope2(),
-        stableRateSlope1: strategy.stableRateSlope1(),
-        stableRateSlope2: strategy.stableRateSlope2()
-      });
-  }
+    ///@inheritdoc IV2RateStrategyFactory
+    function getStrategyDataOfAsset(address asset) external view returns (RateStrategyParams memory) {
+        RateStrategyParams memory params;
+
+        IDefaultInterestRateStrategy strategy = IDefaultInterestRateStrategy(
+            ILendingPool(ADDRESSES_PROVIDER.getLendingPool()).getReserveData(asset).interestRateStrategyAddress
+        );
+
+        if (address(strategy) != address(0)) {
+            params = getStrategyData(strategy);
+        }
+
+        return params;
+    }
+
+    ///@inheritdoc IV2RateStrategyFactory
+    function getStrategyData(IDefaultInterestRateStrategy strategy) public view returns (RateStrategyParams memory) {
+        return RateStrategyParams({
+            optimalUtilizationRate: strategy.OPTIMAL_UTILIZATION_RATE(),
+            baseVariableBorrowRate: strategy.baseVariableBorrowRate(),
+            variableRateSlope1: strategy.variableRateSlope1(),
+            variableRateSlope2: strategy.variableRateSlope2(),
+            stableRateSlope1: strategy.stableRateSlope1(),
+            stableRateSlope2: strategy.stableRateSlope2()
+        });
+    }
 }

--- a/src/v2-config-engine/libraries/BorrowV2Engine.sol
+++ b/src/v2-config-engine/libraries/BorrowV2Engine.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {EngineFlags} from '../../v3-config-engine/EngineFlags.sol';
+import {ReserveConfiguration, DataTypes} from '../protocol-v2/ReserveConfiguration.sol';
+import {IAaveV2ConfigEngine as IEngine, ILendingPoolConfigurator as IPoolConfigurator, ILendingPool as IPool} from '../IAaveV2ConfigEngine.sol';
+
+library BorrowV2Engine {
+  using ReserveConfiguration for DataTypes.ReserveConfigurationMap;
+
+  function executeBorrowSide(
+    IEngine.EngineConstants calldata engineConstants,
+    IEngine.BorrowUpdate[] memory updates
+  ) external {
+    require(updates.length != 0, 'AT_LEAST_ONE_UPDATE_REQUIRED');
+
+    _configBorrowSide(engineConstants.poolConfigurator, engineConstants.pool, updates);
+  }
+
+  function _configBorrowSide(
+    IPoolConfigurator poolConfigurator,
+    IPool pool,
+    IEngine.BorrowUpdate[] memory updates
+  ) internal {
+    for (uint256 i = 0; i < updates.length; i++) {
+      if (updates[i].enabledToBorrow != EngineFlags.KEEP_CURRENT) {
+        if (EngineFlags.toBool(updates[i].enabledToBorrow)) {
+          poolConfigurator.enableBorrowingOnReserve(
+            updates[i].asset,
+            // We disable it here to avoid default activating stable rate borrowing
+            false
+          );
+        } else {
+          poolConfigurator.disableBorrowingOnReserve(updates[i].asset);
+        }
+      } else {
+        DataTypes.ReserveConfigurationMap memory reserveConfig = pool.getConfiguration(
+          updates[i].asset
+        );
+        (, , bool borrowingEnabled, ) = reserveConfig.getFlags();
+        updates[i].enabledToBorrow = EngineFlags.fromBool(borrowingEnabled);
+      }
+
+      if (updates[i].enabledToBorrow == EngineFlags.ENABLED) {
+        if (
+          updates[i].stableRateModeEnabled != EngineFlags.KEEP_CURRENT &&
+          EngineFlags.toBool(updates[i].stableRateModeEnabled)
+        ) {
+          poolConfigurator.enableReserveStableRate(updates[i].asset);
+        } else {
+          poolConfigurator.disableReserveStableRate(updates[i].asset);
+        }
+      }
+
+      // The reserve factor should always be > 0
+      require(
+        (updates[i].reserveFactor > 0 && updates[i].reserveFactor <= 100_00) ||
+          updates[i].reserveFactor == EngineFlags.KEEP_CURRENT,
+        'INVALID_RESERVE_FACTOR'
+      );
+
+      if (updates[i].reserveFactor != EngineFlags.KEEP_CURRENT) {
+        poolConfigurator.setReserveFactor(updates[i].asset, updates[i].reserveFactor);
+      }
+    }
+  }
+}

--- a/src/v2-config-engine/libraries/CollateralV2Engine.sol
+++ b/src/v2-config-engine/libraries/CollateralV2Engine.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {EngineFlags} from '../../v3-config-engine/EngineFlags.sol';
+import {ReserveConfiguration, DataTypes} from '../protocol-v2/ReserveConfiguration.sol';
+import {IAaveV2ConfigEngine as IEngine, ILendingPoolConfigurator as IPoolConfigurator, ILendingPool as IPool} from '../IAaveV2ConfigEngine.sol';
+import {PercentageMath} from 'aave-v3-core/contracts/protocol/libraries/math/PercentageMath.sol';
+
+library CollateralV2Engine {
+  using ReserveConfiguration for DataTypes.ReserveConfigurationMap;
+  using PercentageMath for uint256;
+
+  function executeCollateralSide(
+    IEngine.EngineConstants calldata engineConstants,
+    IEngine.CollateralUpdate[] memory updates
+  ) external {
+    require(updates.length != 0, 'AT_LEAST_ONE_UPDATE_REQUIRED');
+
+    _configCollateralSide(engineConstants.poolConfigurator, engineConstants.pool, updates);
+  }
+
+  function _configCollateralSide(
+    IPoolConfigurator poolConfigurator,
+    IPool pool,
+    IEngine.CollateralUpdate[] memory updates
+  ) internal {
+    for (uint256 i = 0; i < updates.length; i++) {
+      if (updates[i].liqThreshold != 0) {
+        bool notAllKeepCurrent = updates[i].ltv != EngineFlags.KEEP_CURRENT ||
+          updates[i].liqThreshold != EngineFlags.KEEP_CURRENT ||
+          updates[i].liqBonus != EngineFlags.KEEP_CURRENT;
+
+        bool atLeastOneKeepCurrent = updates[i].ltv == EngineFlags.KEEP_CURRENT ||
+          updates[i].liqThreshold == EngineFlags.KEEP_CURRENT ||
+          updates[i].liqBonus == EngineFlags.KEEP_CURRENT;
+
+        if (notAllKeepCurrent && atLeastOneKeepCurrent) {
+          DataTypes.ReserveConfigurationMap memory configuration = pool.getConfiguration(
+            updates[i].asset
+          );
+          (
+            uint256 currentLtv,
+            uint256 currentLiqThreshold,
+            uint256 currentLiqBonus,
+            ,
+
+          ) = configuration.getParams();
+
+          if (updates[i].ltv == EngineFlags.KEEP_CURRENT) {
+            updates[i].ltv = currentLtv;
+          }
+
+          if (updates[i].liqThreshold == EngineFlags.KEEP_CURRENT) {
+            updates[i].liqThreshold = currentLiqThreshold;
+          }
+
+          if (updates[i].liqBonus == EngineFlags.KEEP_CURRENT) {
+            // Subtracting 100_00 to be consistent with the engine as 100_00 gets added while setting the liqBonus
+            updates[i].liqBonus = currentLiqBonus - 100_00;
+          }
+        }
+
+        if (notAllKeepCurrent) {
+          // LT*LB (in %) should never be above 100%, because it means instant undercollateralization
+          require(
+            updates[i].liqThreshold.percentMul(100_00 + updates[i].liqBonus) <= 100_00,
+            'INVALID_LT_LB_RATIO'
+          );
+
+          poolConfigurator.configureReserveAsCollateral(
+            updates[i].asset,
+            updates[i].ltv,
+            updates[i].liqThreshold,
+            // For reference, this is to simplify the interaction with the Aave protocol,
+            // as there the definition is as e.g. 105% (5% bonus for liquidators)
+            100_00 + updates[i].liqBonus
+          );
+        }
+      }
+    }
+  }
+}

--- a/src/v2-config-engine/libraries/ListingV2Engine.sol
+++ b/src/v2-config-engine/libraries/ListingV2Engine.sol
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {IERC20Metadata} from 'solidity-utils/contracts/oz-common/interfaces/IERC20Metadata.sol';
+import {IAaveV2ConfigEngine as IEngine, ILendingPoolConfigurator as IPoolConfigurator, IV2RateStrategyFactory, ILendingPool as IPool} from '../IAaveV2ConfigEngine.sol';
+import {PriceFeedEngine} from '../../v3-config-engine/libraries/PriceFeedEngine.sol';
+import {BorrowV2Engine as BorrowEngine} from './BorrowV2Engine.sol';
+import {CollateralV2Engine as CollateralEngine} from './CollateralV2Engine.sol';
+import {ConfiguratorInputTypes} from 'aave-address-book/AaveV2.sol';
+import {Address} from 'solidity-utils/contracts/oz-common/Address.sol';
+
+library ListingV2Engine {
+  using Address for address;
+
+  function executeCustomAssetListing(
+    IEngine.PoolContext calldata context,
+    IEngine.EngineConstants calldata engineConstants,
+    IEngine.EngineLibraries calldata engineLibraries,
+    IEngine.ListingWithCustomImpl[] calldata listings
+  ) external {
+    require(listings.length != 0, 'AT_LEAST_ONE_ASSET_REQUIRED');
+
+    IEngine.RepackedListings memory repacked = _repackListing(listings);
+
+    engineLibraries.priceFeedEngine.functionDelegateCall(
+      abi.encodeWithSelector(
+        PriceFeedEngine.executePriceFeedsUpdate.selector,
+        engineConstants,
+        repacked.priceFeedsUpdates
+      )
+    );
+
+    _initAssets(
+      context,
+      engineConstants.poolConfigurator,
+      engineConstants.ratesStrategyFactory,
+      engineConstants.collector,
+      engineConstants.rewardsController,
+      repacked.ids,
+      repacked.basics,
+      repacked.rates
+    );
+
+    engineLibraries.borrowEngine.functionDelegateCall(
+      abi.encodeWithSelector(
+        BorrowEngine.executeBorrowSide.selector,
+        engineConstants,
+        repacked.borrowsUpdates
+      )
+    );
+
+    engineLibraries.collateralEngine.functionDelegateCall(
+      abi.encodeWithSelector(
+        CollateralEngine.executeCollateralSide.selector,
+        engineConstants,
+        repacked.collateralsUpdates
+      )
+    );
+  }
+
+  function _repackListing(
+    IEngine.ListingWithCustomImpl[] calldata listings
+  ) internal pure returns (IEngine.RepackedListings memory) {
+    address[] memory ids = new address[](listings.length);
+    IEngine.BorrowUpdate[] memory borrowsUpdates = new IEngine.BorrowUpdate[](listings.length);
+    IEngine.CollateralUpdate[] memory collateralsUpdates = new IEngine.CollateralUpdate[](
+      listings.length
+    );
+    IEngine.PriceFeedUpdate[] memory priceFeedsUpdates = new IEngine.PriceFeedUpdate[](
+      listings.length
+    );
+
+    IEngine.Basic[] memory basics = new IEngine.Basic[](listings.length);
+    IV2RateStrategyFactory.RateStrategyParams[]
+      memory rates = new IV2RateStrategyFactory.RateStrategyParams[](listings.length);
+
+    for (uint256 i = 0; i < listings.length; i++) {
+      require(listings[i].base.asset != address(0), 'INVALID_ASSET');
+      ids[i] = listings[i].base.asset;
+      basics[i] = IEngine.Basic({
+        assetSymbol: listings[i].base.assetSymbol,
+        assetName: listings[i].base.assetName,
+        implementations: listings[i].implementations
+      });
+      priceFeedsUpdates[i] = IEngine.PriceFeedUpdate({
+        asset: listings[i].base.asset,
+        priceFeed: listings[i].base.priceFeed
+      });
+      borrowsUpdates[i] = IEngine.BorrowUpdate({
+        asset: listings[i].base.asset,
+        enabledToBorrow: listings[i].base.enabledToBorrow,
+        stableRateModeEnabled: listings[i].base.stableRateModeEnabled,
+        reserveFactor: listings[i].base.reserveFactor
+      });
+      collateralsUpdates[i] = IEngine.CollateralUpdate({
+        asset: listings[i].base.asset,
+        ltv: listings[i].base.ltv,
+        liqThreshold: listings[i].base.liqThreshold,
+        liqBonus: listings[i].base.liqBonus
+      });
+    }
+
+    return
+      IEngine.RepackedListings(
+        ids,
+        basics,
+        borrowsUpdates,
+        collateralsUpdates,
+        priceFeedsUpdates,
+        rates
+      );
+  }
+
+  /// @dev mandatory configurations for any asset getting listed, including oracle config and basic init
+  function _initAssets(
+    IEngine.PoolContext calldata context,
+    IPoolConfigurator poolConfigurator,
+    IV2RateStrategyFactory rateStrategiesFactory,
+    address collector,
+    address rewardsController,
+    address[] memory ids,
+    IEngine.Basic[] memory basics,
+    IV2RateStrategyFactory.RateStrategyParams[] memory rates
+  ) internal {
+    ConfiguratorInputTypes.InitReserveInput[]
+      memory initReserveInputs = new ConfiguratorInputTypes.InitReserveInput[](ids.length);
+    address[] memory strategies = rateStrategiesFactory.createStrategies(rates);
+
+    for (uint256 i = 0; i < ids.length; i++) {
+      uint8 decimals = IERC20Metadata(ids[i]).decimals();
+      require(decimals > 0, 'INVALID_ASSET_DECIMALS');
+
+      initReserveInputs[i] = ConfiguratorInputTypes.InitReserveInput({
+        aTokenImpl: basics[i].implementations.aToken,
+        stableDebtTokenImpl: basics[i].implementations.sToken,
+        variableDebtTokenImpl: basics[i].implementations.vToken,
+        underlyingAssetDecimals: decimals,
+        interestRateStrategyAddress: strategies[i],
+        underlyingAsset: ids[i],
+        treasury: collector,
+        incentivesController: rewardsController,
+        underlyingAssetName: basics[i].assetName,
+        aTokenName: string.concat('Aave ', context.networkName, ' ', basics[i].assetSymbol),
+        aTokenSymbol: string.concat('a', context.networkAbbreviation, basics[i].assetSymbol),
+        variableDebtTokenName: string.concat(
+          'Aave ',
+          context.networkName,
+          ' Variable Debt ',
+          basics[i].assetSymbol
+        ),
+        variableDebtTokenSymbol: string.concat(
+          'variableDebt',
+          context.networkAbbreviation,
+          basics[i].assetSymbol
+        ),
+        stableDebtTokenName: string.concat(
+          'Aave ',
+          context.networkName,
+          ' Stable Debt ',
+          basics[i].assetSymbol
+        ),
+        stableDebtTokenSymbol: string.concat(
+          'stableDebt',
+          context.networkAbbreviation,
+          basics[i].assetSymbol
+        ),
+        params: bytes('')
+      });
+    }
+    poolConfigurator.batchInitReserve(initReserveInputs);
+  }
+}

--- a/src/v2-config-engine/libraries/RateV2Engine.sol
+++ b/src/v2-config-engine/libraries/RateV2Engine.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {EngineFlags} from '../../v3-config-engine/EngineFlags.sol';
+import {IAaveV2ConfigEngine as IEngine, ILendingPoolConfigurator as IPoolConfigurator, IV2RateStrategyFactory} from '../IAaveV2ConfigEngine.sol';
+
+library RateV2Engine {
+  function executeRateStrategiesUpdate(
+    IEngine.EngineConstants calldata engineConstants,
+    IEngine.RateStrategyUpdate[] memory updates
+  ) external {
+    require(updates.length != 0, 'AT_LEAST_ONE_UPDATE_REQUIRED');
+
+    (
+      address[] memory ids,
+      IV2RateStrategyFactory.RateStrategyParams[] memory rates
+    ) = _repackRatesUpdate(updates);
+
+    _configRateStrategies(
+      engineConstants.poolConfigurator,
+      engineConstants.ratesStrategyFactory,
+      ids,
+      rates
+    );
+  }
+
+  function _configRateStrategies(
+    IPoolConfigurator poolConfigurator,
+    IV2RateStrategyFactory rateStrategiesFactory,
+    address[] memory ids,
+    IV2RateStrategyFactory.RateStrategyParams[] memory strategiesParams
+  ) internal {
+    for (uint256 i = 0; i < strategiesParams.length; i++) {
+      if (
+        strategiesParams[i].variableRateSlope1 == EngineFlags.KEEP_CURRENT ||
+        strategiesParams[i].variableRateSlope2 == EngineFlags.KEEP_CURRENT ||
+        strategiesParams[i].optimalUtilizationRate == EngineFlags.KEEP_CURRENT ||
+        strategiesParams[i].baseVariableBorrowRate == EngineFlags.KEEP_CURRENT ||
+        strategiesParams[i].stableRateSlope1 == EngineFlags.KEEP_CURRENT ||
+        strategiesParams[i].stableRateSlope2 == EngineFlags.KEEP_CURRENT
+      ) {
+        IV2RateStrategyFactory.RateStrategyParams memory currentStrategyData = rateStrategiesFactory
+          .getStrategyDataOfAsset(ids[i]);
+
+        if (strategiesParams[i].variableRateSlope1 == EngineFlags.KEEP_CURRENT) {
+          strategiesParams[i].variableRateSlope1 = currentStrategyData.variableRateSlope1;
+        }
+
+        if (strategiesParams[i].variableRateSlope2 == EngineFlags.KEEP_CURRENT) {
+          strategiesParams[i].variableRateSlope2 = currentStrategyData.variableRateSlope2;
+        }
+
+        if (strategiesParams[i].optimalUtilizationRate == EngineFlags.KEEP_CURRENT) {
+          strategiesParams[i].optimalUtilizationRate = currentStrategyData.optimalUtilizationRate;
+        }
+
+        if (strategiesParams[i].baseVariableBorrowRate == EngineFlags.KEEP_CURRENT) {
+          strategiesParams[i].baseVariableBorrowRate = currentStrategyData.baseVariableBorrowRate;
+        }
+
+        if (strategiesParams[i].stableRateSlope1 == EngineFlags.KEEP_CURRENT) {
+          strategiesParams[i].stableRateSlope1 = currentStrategyData.stableRateSlope1;
+        }
+
+        if (strategiesParams[i].stableRateSlope2 == EngineFlags.KEEP_CURRENT) {
+          strategiesParams[i].stableRateSlope2 = currentStrategyData.stableRateSlope2;
+        }
+      }
+    }
+
+    address[] memory strategies = rateStrategiesFactory.createStrategies(strategiesParams);
+
+    for (uint256 i = 0; i < strategies.length; i++) {
+      poolConfigurator.setReserveInterestRateStrategyAddress(ids[i], strategies[i]);
+    }
+  }
+
+  function _repackRatesUpdate(
+    IEngine.RateStrategyUpdate[] memory updates
+  ) internal pure returns (address[] memory, IV2RateStrategyFactory.RateStrategyParams[] memory) {
+    address[] memory ids = new address[](updates.length);
+    IV2RateStrategyFactory.RateStrategyParams[]
+      memory rates = new IV2RateStrategyFactory.RateStrategyParams[](updates.length);
+
+    for (uint256 i = 0; i < updates.length; i++) {
+      ids[i] = updates[i].asset;
+      rates[i] = updates[i].params;
+    }
+    return (ids, rates);
+  }
+}

--- a/src/v2-config-engine/protocol-v2/ReserveConfiguration.sol
+++ b/src/v2-config-engine/protocol-v2/ReserveConfiguration.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
-import {DataTypes} from "aave-address-book/AaveV2.sol";
+import {DataTypes} from 'aave-address-book/AaveV2.sol';
 
 /**
  * @title ReserveConfiguration library
@@ -9,304 +9,339 @@ import {DataTypes} from "aave-address-book/AaveV2.sol";
  * @notice Implements the bitmap logic to handle the reserve configuration
  */
 library ReserveConfiguration {
-    uint256 constant LTV_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000; // prettier-ignore
-    uint256 constant LIQUIDATION_THRESHOLD_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000FFFF; // prettier-ignore
-    uint256 constant LIQUIDATION_BONUS_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000FFFFFFFF; // prettier-ignore
-    uint256 constant DECIMALS_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00FFFFFFFFFFFF; // prettier-ignore
-    uint256 constant ACTIVE_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFFFFFFFFFF; // prettier-ignore
-    uint256 constant FROZEN_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFDFFFFFFFFFFFFFF; // prettier-ignore
-    uint256 constant BORROWING_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFF; // prettier-ignore
-    uint256 constant STABLE_BORROWING_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7FFFFFFFFFFFFFF; // prettier-ignore
-    uint256 constant RESERVE_FACTOR_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000FFFFFFFFFFFFFFFF; // prettier-ignore
+  uint256 constant LTV_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000; // prettier-ignore
+  uint256 constant LIQUIDATION_THRESHOLD_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000FFFF; // prettier-ignore
+  uint256 constant LIQUIDATION_BONUS_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000FFFFFFFF; // prettier-ignore
+  uint256 constant DECIMALS_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00FFFFFFFFFFFF; // prettier-ignore
+  uint256 constant ACTIVE_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFFFFFFFFFF; // prettier-ignore
+  uint256 constant FROZEN_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFDFFFFFFFFFFFFFF; // prettier-ignore
+  uint256 constant BORROWING_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFF; // prettier-ignore
+  uint256 constant STABLE_BORROWING_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7FFFFFFFFFFFFFF; // prettier-ignore
+  uint256 constant RESERVE_FACTOR_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000FFFFFFFFFFFFFFFF; // prettier-ignore
 
-    /// @dev For the LTV, the start bit is 0 (up to 15), hence no bitshifting is needed
-    uint256 constant LIQUIDATION_THRESHOLD_START_BIT_POSITION = 16;
-    uint256 constant LIQUIDATION_BONUS_START_BIT_POSITION = 32;
-    uint256 constant RESERVE_DECIMALS_START_BIT_POSITION = 48;
-    uint256 constant IS_ACTIVE_START_BIT_POSITION = 56;
-    uint256 constant IS_FROZEN_START_BIT_POSITION = 57;
-    uint256 constant BORROWING_ENABLED_START_BIT_POSITION = 58;
-    uint256 constant STABLE_BORROWING_ENABLED_START_BIT_POSITION = 59;
-    uint256 constant RESERVE_FACTOR_START_BIT_POSITION = 64;
+  /// @dev For the LTV, the start bit is 0 (up to 15), hence no bitshifting is needed
+  uint256 constant LIQUIDATION_THRESHOLD_START_BIT_POSITION = 16;
+  uint256 constant LIQUIDATION_BONUS_START_BIT_POSITION = 32;
+  uint256 constant RESERVE_DECIMALS_START_BIT_POSITION = 48;
+  uint256 constant IS_ACTIVE_START_BIT_POSITION = 56;
+  uint256 constant IS_FROZEN_START_BIT_POSITION = 57;
+  uint256 constant BORROWING_ENABLED_START_BIT_POSITION = 58;
+  uint256 constant STABLE_BORROWING_ENABLED_START_BIT_POSITION = 59;
+  uint256 constant RESERVE_FACTOR_START_BIT_POSITION = 64;
 
-    uint256 constant MAX_VALID_LTV = 65535;
-    uint256 constant MAX_VALID_LIQUIDATION_THRESHOLD = 65535;
-    uint256 constant MAX_VALID_LIQUIDATION_BONUS = 65535;
-    uint256 constant MAX_VALID_DECIMALS = 255;
-    uint256 constant MAX_VALID_RESERVE_FACTOR = 65535;
+  uint256 constant MAX_VALID_LTV = 65535;
+  uint256 constant MAX_VALID_LIQUIDATION_THRESHOLD = 65535;
+  uint256 constant MAX_VALID_LIQUIDATION_BONUS = 65535;
+  uint256 constant MAX_VALID_DECIMALS = 255;
+  uint256 constant MAX_VALID_RESERVE_FACTOR = 65535;
 
-    /**
-     * @dev Sets the Loan to Value of the reserve
-     * @param self The reserve configuration
-     * @param ltv the new ltv
-     *
-     */
-    function setLtv(DataTypes.ReserveConfigurationMap memory self, uint256 ltv) internal pure {
-        require(ltv <= MAX_VALID_LTV, Errors.RC_INVALID_LTV);
+  /**
+   * @dev Sets the Loan to Value of the reserve
+   * @param self The reserve configuration
+   * @param ltv the new ltv
+   *
+   */
+  function setLtv(DataTypes.ReserveConfigurationMap memory self, uint256 ltv) internal pure {
+    require(ltv <= MAX_VALID_LTV, Errors.RC_INVALID_LTV);
 
-        self.data = (self.data & LTV_MASK) | ltv;
-    }
+    self.data = (self.data & LTV_MASK) | ltv;
+  }
 
-    /**
-     * @dev Gets the Loan to Value of the reserve
-     * @param self The reserve configuration
-     * @return The loan to value
-     *
-     */
-    function getLtv(DataTypes.ReserveConfigurationMap storage self) internal view returns (uint256) {
-        return self.data & ~LTV_MASK;
-    }
+  /**
+   * @dev Gets the Loan to Value of the reserve
+   * @param self The reserve configuration
+   * @return The loan to value
+   *
+   */
+  function getLtv(DataTypes.ReserveConfigurationMap storage self) internal view returns (uint256) {
+    return self.data & ~LTV_MASK;
+  }
 
-    /**
-     * @dev Sets the liquidation threshold of the reserve
-     * @param self The reserve configuration
-     * @param threshold The new liquidation threshold
-     *
-     */
-    function setLiquidationThreshold(DataTypes.ReserveConfigurationMap memory self, uint256 threshold) internal pure {
-        require(threshold <= MAX_VALID_LIQUIDATION_THRESHOLD, Errors.RC_INVALID_LIQ_THRESHOLD);
+  /**
+   * @dev Sets the liquidation threshold of the reserve
+   * @param self The reserve configuration
+   * @param threshold The new liquidation threshold
+   *
+   */
+  function setLiquidationThreshold(
+    DataTypes.ReserveConfigurationMap memory self,
+    uint256 threshold
+  ) internal pure {
+    require(threshold <= MAX_VALID_LIQUIDATION_THRESHOLD, Errors.RC_INVALID_LIQ_THRESHOLD);
 
-        self.data = (self.data & LIQUIDATION_THRESHOLD_MASK) | (threshold << LIQUIDATION_THRESHOLD_START_BIT_POSITION);
-    }
+    self.data =
+      (self.data & LIQUIDATION_THRESHOLD_MASK) |
+      (threshold << LIQUIDATION_THRESHOLD_START_BIT_POSITION);
+  }
 
-    /**
-     * @dev Gets the liquidation threshold of the reserve
-     * @param self The reserve configuration
-     * @return The liquidation threshold
-     *
-     */
-    function getLiquidationThreshold(DataTypes.ReserveConfigurationMap storage self) internal view returns (uint256) {
-        return (self.data & ~LIQUIDATION_THRESHOLD_MASK) >> LIQUIDATION_THRESHOLD_START_BIT_POSITION;
-    }
+  /**
+   * @dev Gets the liquidation threshold of the reserve
+   * @param self The reserve configuration
+   * @return The liquidation threshold
+   *
+   */
+  function getLiquidationThreshold(
+    DataTypes.ReserveConfigurationMap storage self
+  ) internal view returns (uint256) {
+    return (self.data & ~LIQUIDATION_THRESHOLD_MASK) >> LIQUIDATION_THRESHOLD_START_BIT_POSITION;
+  }
 
-    /**
-     * @dev Sets the liquidation bonus of the reserve
-     * @param self The reserve configuration
-     * @param bonus The new liquidation bonus
-     *
-     */
-    function setLiquidationBonus(DataTypes.ReserveConfigurationMap memory self, uint256 bonus) internal pure {
-        require(bonus <= MAX_VALID_LIQUIDATION_BONUS, Errors.RC_INVALID_LIQ_BONUS);
+  /**
+   * @dev Sets the liquidation bonus of the reserve
+   * @param self The reserve configuration
+   * @param bonus The new liquidation bonus
+   *
+   */
+  function setLiquidationBonus(
+    DataTypes.ReserveConfigurationMap memory self,
+    uint256 bonus
+  ) internal pure {
+    require(bonus <= MAX_VALID_LIQUIDATION_BONUS, Errors.RC_INVALID_LIQ_BONUS);
 
-        self.data = (self.data & LIQUIDATION_BONUS_MASK) | (bonus << LIQUIDATION_BONUS_START_BIT_POSITION);
-    }
+    self.data =
+      (self.data & LIQUIDATION_BONUS_MASK) |
+      (bonus << LIQUIDATION_BONUS_START_BIT_POSITION);
+  }
 
-    /**
-     * @dev Gets the liquidation bonus of the reserve
-     * @param self The reserve configuration
-     * @return The liquidation bonus
-     *
-     */
-    function getLiquidationBonus(DataTypes.ReserveConfigurationMap storage self) internal view returns (uint256) {
-        return (self.data & ~LIQUIDATION_BONUS_MASK) >> LIQUIDATION_BONUS_START_BIT_POSITION;
-    }
+  /**
+   * @dev Gets the liquidation bonus of the reserve
+   * @param self The reserve configuration
+   * @return The liquidation bonus
+   *
+   */
+  function getLiquidationBonus(
+    DataTypes.ReserveConfigurationMap storage self
+  ) internal view returns (uint256) {
+    return (self.data & ~LIQUIDATION_BONUS_MASK) >> LIQUIDATION_BONUS_START_BIT_POSITION;
+  }
 
-    /**
-     * @dev Sets the decimals of the underlying asset of the reserve
-     * @param self The reserve configuration
-     * @param decimals The decimals
-     *
-     */
-    function setDecimals(DataTypes.ReserveConfigurationMap memory self, uint256 decimals) internal pure {
-        require(decimals <= MAX_VALID_DECIMALS, Errors.RC_INVALID_DECIMALS);
+  /**
+   * @dev Sets the decimals of the underlying asset of the reserve
+   * @param self The reserve configuration
+   * @param decimals The decimals
+   *
+   */
+  function setDecimals(
+    DataTypes.ReserveConfigurationMap memory self,
+    uint256 decimals
+  ) internal pure {
+    require(decimals <= MAX_VALID_DECIMALS, Errors.RC_INVALID_DECIMALS);
 
-        self.data = (self.data & DECIMALS_MASK) | (decimals << RESERVE_DECIMALS_START_BIT_POSITION);
-    }
+    self.data = (self.data & DECIMALS_MASK) | (decimals << RESERVE_DECIMALS_START_BIT_POSITION);
+  }
 
-    /**
-     * @dev Gets the decimals of the underlying asset of the reserve
-     * @param self The reserve configuration
-     * @return The decimals of the asset
-     *
-     */
-    function getDecimals(DataTypes.ReserveConfigurationMap storage self) internal view returns (uint256) {
-        return (self.data & ~DECIMALS_MASK) >> RESERVE_DECIMALS_START_BIT_POSITION;
-    }
+  /**
+   * @dev Gets the decimals of the underlying asset of the reserve
+   * @param self The reserve configuration
+   * @return The decimals of the asset
+   *
+   */
+  function getDecimals(
+    DataTypes.ReserveConfigurationMap storage self
+  ) internal view returns (uint256) {
+    return (self.data & ~DECIMALS_MASK) >> RESERVE_DECIMALS_START_BIT_POSITION;
+  }
 
-    /**
-     * @dev Sets the active state of the reserve
-     * @param self The reserve configuration
-     * @param active The active state
-     *
-     */
-    function setActive(DataTypes.ReserveConfigurationMap memory self, bool active) internal pure {
-        self.data = (self.data & ACTIVE_MASK) | (uint256(active ? 1 : 0) << IS_ACTIVE_START_BIT_POSITION);
-    }
+  /**
+   * @dev Sets the active state of the reserve
+   * @param self The reserve configuration
+   * @param active The active state
+   *
+   */
+  function setActive(DataTypes.ReserveConfigurationMap memory self, bool active) internal pure {
+    self.data =
+      (self.data & ACTIVE_MASK) |
+      (uint256(active ? 1 : 0) << IS_ACTIVE_START_BIT_POSITION);
+  }
 
-    /**
-     * @dev Gets the active state of the reserve
-     * @param self The reserve configuration
-     * @return The active state
-     *
-     */
-    function getActive(DataTypes.ReserveConfigurationMap storage self) internal view returns (bool) {
-        return (self.data & ~ACTIVE_MASK) != 0;
-    }
+  /**
+   * @dev Gets the active state of the reserve
+   * @param self The reserve configuration
+   * @return The active state
+   *
+   */
+  function getActive(DataTypes.ReserveConfigurationMap storage self) internal view returns (bool) {
+    return (self.data & ~ACTIVE_MASK) != 0;
+  }
 
-    /**
-     * @dev Sets the frozen state of the reserve
-     * @param self The reserve configuration
-     * @param frozen The frozen state
-     *
-     */
-    function setFrozen(DataTypes.ReserveConfigurationMap memory self, bool frozen) internal pure {
-        self.data = (self.data & FROZEN_MASK) | (uint256(frozen ? 1 : 0) << IS_FROZEN_START_BIT_POSITION);
-    }
+  /**
+   * @dev Sets the frozen state of the reserve
+   * @param self The reserve configuration
+   * @param frozen The frozen state
+   *
+   */
+  function setFrozen(DataTypes.ReserveConfigurationMap memory self, bool frozen) internal pure {
+    self.data =
+      (self.data & FROZEN_MASK) |
+      (uint256(frozen ? 1 : 0) << IS_FROZEN_START_BIT_POSITION);
+  }
 
-    /**
-     * @dev Gets the frozen state of the reserve
-     * @param self The reserve configuration
-     * @return The frozen state
-     *
-     */
-    function getFrozen(DataTypes.ReserveConfigurationMap storage self) internal view returns (bool) {
-        return (self.data & ~FROZEN_MASK) != 0;
-    }
+  /**
+   * @dev Gets the frozen state of the reserve
+   * @param self The reserve configuration
+   * @return The frozen state
+   *
+   */
+  function getFrozen(DataTypes.ReserveConfigurationMap storage self) internal view returns (bool) {
+    return (self.data & ~FROZEN_MASK) != 0;
+  }
 
-    /**
-     * @dev Enables or disables borrowing on the reserve
-     * @param self The reserve configuration
-     * @param enabled True if the borrowing needs to be enabled, false otherwise
-     *
-     */
-    function setBorrowingEnabled(DataTypes.ReserveConfigurationMap memory self, bool enabled) internal pure {
-        self.data = (self.data & BORROWING_MASK) | (uint256(enabled ? 1 : 0) << BORROWING_ENABLED_START_BIT_POSITION);
-    }
+  /**
+   * @dev Enables or disables borrowing on the reserve
+   * @param self The reserve configuration
+   * @param enabled True if the borrowing needs to be enabled, false otherwise
+   *
+   */
+  function setBorrowingEnabled(
+    DataTypes.ReserveConfigurationMap memory self,
+    bool enabled
+  ) internal pure {
+    self.data =
+      (self.data & BORROWING_MASK) |
+      (uint256(enabled ? 1 : 0) << BORROWING_ENABLED_START_BIT_POSITION);
+  }
 
-    /**
-     * @dev Gets the borrowing state of the reserve
-     * @param self The reserve configuration
-     * @return The borrowing state
-     *
-     */
-    function getBorrowingEnabled(DataTypes.ReserveConfigurationMap storage self) internal view returns (bool) {
-        return (self.data & ~BORROWING_MASK) != 0;
-    }
+  /**
+   * @dev Gets the borrowing state of the reserve
+   * @param self The reserve configuration
+   * @return The borrowing state
+   *
+   */
+  function getBorrowingEnabled(
+    DataTypes.ReserveConfigurationMap storage self
+  ) internal view returns (bool) {
+    return (self.data & ~BORROWING_MASK) != 0;
+  }
 
-    /**
-     * @dev Enables or disables stable rate borrowing on the reserve
-     * @param self The reserve configuration
-     * @param enabled True if the stable rate borrowing needs to be enabled, false otherwise
-     *
-     */
-    function setStableRateBorrowingEnabled(DataTypes.ReserveConfigurationMap memory self, bool enabled) internal pure {
-        self.data = (self.data & STABLE_BORROWING_MASK)
-            | (uint256(enabled ? 1 : 0) << STABLE_BORROWING_ENABLED_START_BIT_POSITION);
-    }
+  /**
+   * @dev Enables or disables stable rate borrowing on the reserve
+   * @param self The reserve configuration
+   * @param enabled True if the stable rate borrowing needs to be enabled, false otherwise
+   *
+   */
+  function setStableRateBorrowingEnabled(
+    DataTypes.ReserveConfigurationMap memory self,
+    bool enabled
+  ) internal pure {
+    self.data =
+      (self.data & STABLE_BORROWING_MASK) |
+      (uint256(enabled ? 1 : 0) << STABLE_BORROWING_ENABLED_START_BIT_POSITION);
+  }
 
-    /**
-     * @dev Gets the stable rate borrowing state of the reserve
-     * @param self The reserve configuration
-     * @return The stable rate borrowing state
-     *
-     */
-    function getStableRateBorrowingEnabled(DataTypes.ReserveConfigurationMap storage self)
-        internal
-        view
-        returns (bool)
-    {
-        return (self.data & ~STABLE_BORROWING_MASK) != 0;
-    }
+  /**
+   * @dev Gets the stable rate borrowing state of the reserve
+   * @param self The reserve configuration
+   * @return The stable rate borrowing state
+   *
+   */
+  function getStableRateBorrowingEnabled(
+    DataTypes.ReserveConfigurationMap storage self
+  ) internal view returns (bool) {
+    return (self.data & ~STABLE_BORROWING_MASK) != 0;
+  }
 
-    /**
-     * @dev Sets the reserve factor of the reserve
-     * @param self The reserve configuration
-     * @param reserveFactor The reserve factor
-     *
-     */
-    function setReserveFactor(DataTypes.ReserveConfigurationMap memory self, uint256 reserveFactor) internal pure {
-        require(reserveFactor <= MAX_VALID_RESERVE_FACTOR, Errors.RC_INVALID_RESERVE_FACTOR);
+  /**
+   * @dev Sets the reserve factor of the reserve
+   * @param self The reserve configuration
+   * @param reserveFactor The reserve factor
+   *
+   */
+  function setReserveFactor(
+    DataTypes.ReserveConfigurationMap memory self,
+    uint256 reserveFactor
+  ) internal pure {
+    require(reserveFactor <= MAX_VALID_RESERVE_FACTOR, Errors.RC_INVALID_RESERVE_FACTOR);
 
-        self.data = (self.data & RESERVE_FACTOR_MASK) | (reserveFactor << RESERVE_FACTOR_START_BIT_POSITION);
-    }
+    self.data =
+      (self.data & RESERVE_FACTOR_MASK) |
+      (reserveFactor << RESERVE_FACTOR_START_BIT_POSITION);
+  }
 
-    /**
-     * @dev Gets the reserve factor of the reserve
-     * @param self The reserve configuration
-     * @return The reserve factor
-     *
-     */
-    function getReserveFactor(DataTypes.ReserveConfigurationMap storage self) internal view returns (uint256) {
-        return (self.data & ~RESERVE_FACTOR_MASK) >> RESERVE_FACTOR_START_BIT_POSITION;
-    }
+  /**
+   * @dev Gets the reserve factor of the reserve
+   * @param self The reserve configuration
+   * @return The reserve factor
+   *
+   */
+  function getReserveFactor(
+    DataTypes.ReserveConfigurationMap storage self
+  ) internal view returns (uint256) {
+    return (self.data & ~RESERVE_FACTOR_MASK) >> RESERVE_FACTOR_START_BIT_POSITION;
+  }
 
-    /**
-     * @dev Gets the configuration flags of the reserve
-     * @param self The reserve configuration
-     * @return The state flags representing active, frozen, borrowing enabled, stableRateBorrowing enabled
-     *
-     */
-    function getFlags(DataTypes.ReserveConfigurationMap memory self) internal pure returns (bool, bool, bool, bool) {
-        uint256 dataLocal = self.data;
+  /**
+   * @dev Gets the configuration flags of the reserve
+   * @param self The reserve configuration
+   * @return The state flags representing active, frozen, borrowing enabled, stableRateBorrowing enabled
+   *
+   */
+  function getFlags(
+    DataTypes.ReserveConfigurationMap memory self
+  ) internal pure returns (bool, bool, bool, bool) {
+    uint256 dataLocal = self.data;
 
-        return (
-            (dataLocal & ~ACTIVE_MASK) != 0,
-            (dataLocal & ~FROZEN_MASK) != 0,
-            (dataLocal & ~BORROWING_MASK) != 0,
-            (dataLocal & ~STABLE_BORROWING_MASK) != 0
-        );
-    }
+    return (
+      (dataLocal & ~ACTIVE_MASK) != 0,
+      (dataLocal & ~FROZEN_MASK) != 0,
+      (dataLocal & ~BORROWING_MASK) != 0,
+      (dataLocal & ~STABLE_BORROWING_MASK) != 0
+    );
+  }
 
-    /**
-     * @dev Gets the configuration paramters of the reserve
-     * @param self The reserve configuration
-     * @return The state params representing ltv, liquidation threshold, liquidation bonus, the reserve decimals
-     *
-     */
-    function getParams(DataTypes.ReserveConfigurationMap memory self)
-        internal
-        pure
-        returns (uint256, uint256, uint256, uint256, uint256)
-    {
-        uint256 dataLocal = self.data;
+  /**
+   * @dev Gets the configuration paramters of the reserve
+   * @param self The reserve configuration
+   * @return The state params representing ltv, liquidation threshold, liquidation bonus, the reserve decimals
+   *
+   */
+  function getParams(
+    DataTypes.ReserveConfigurationMap memory self
+  ) internal pure returns (uint256, uint256, uint256, uint256, uint256) {
+    uint256 dataLocal = self.data;
 
-        return (
-            dataLocal & ~LTV_MASK,
-            (dataLocal & ~LIQUIDATION_THRESHOLD_MASK) >> LIQUIDATION_THRESHOLD_START_BIT_POSITION,
-            (dataLocal & ~LIQUIDATION_BONUS_MASK) >> LIQUIDATION_BONUS_START_BIT_POSITION,
-            (dataLocal & ~DECIMALS_MASK) >> RESERVE_DECIMALS_START_BIT_POSITION,
-            (dataLocal & ~RESERVE_FACTOR_MASK) >> RESERVE_FACTOR_START_BIT_POSITION
-        );
-    }
+    return (
+      dataLocal & ~LTV_MASK,
+      (dataLocal & ~LIQUIDATION_THRESHOLD_MASK) >> LIQUIDATION_THRESHOLD_START_BIT_POSITION,
+      (dataLocal & ~LIQUIDATION_BONUS_MASK) >> LIQUIDATION_BONUS_START_BIT_POSITION,
+      (dataLocal & ~DECIMALS_MASK) >> RESERVE_DECIMALS_START_BIT_POSITION,
+      (dataLocal & ~RESERVE_FACTOR_MASK) >> RESERVE_FACTOR_START_BIT_POSITION
+    );
+  }
 
-    /**
-     * @dev Gets the configuration paramters of the reserve from a memory object
-     * @param self The reserve configuration
-     * @return The state params representing ltv, liquidation threshold, liquidation bonus, the reserve decimals
-     *
-     */
-    function getParamsMemory(DataTypes.ReserveConfigurationMap memory self)
-        internal
-        pure
-        returns (uint256, uint256, uint256, uint256, uint256)
-    {
-        return (
-            self.data & ~LTV_MASK,
-            (self.data & ~LIQUIDATION_THRESHOLD_MASK) >> LIQUIDATION_THRESHOLD_START_BIT_POSITION,
-            (self.data & ~LIQUIDATION_BONUS_MASK) >> LIQUIDATION_BONUS_START_BIT_POSITION,
-            (self.data & ~DECIMALS_MASK) >> RESERVE_DECIMALS_START_BIT_POSITION,
-            (self.data & ~RESERVE_FACTOR_MASK) >> RESERVE_FACTOR_START_BIT_POSITION
-        );
-    }
+  /**
+   * @dev Gets the configuration paramters of the reserve from a memory object
+   * @param self The reserve configuration
+   * @return The state params representing ltv, liquidation threshold, liquidation bonus, the reserve decimals
+   *
+   */
+  function getParamsMemory(
+    DataTypes.ReserveConfigurationMap memory self
+  ) internal pure returns (uint256, uint256, uint256, uint256, uint256) {
+    return (
+      self.data & ~LTV_MASK,
+      (self.data & ~LIQUIDATION_THRESHOLD_MASK) >> LIQUIDATION_THRESHOLD_START_BIT_POSITION,
+      (self.data & ~LIQUIDATION_BONUS_MASK) >> LIQUIDATION_BONUS_START_BIT_POSITION,
+      (self.data & ~DECIMALS_MASK) >> RESERVE_DECIMALS_START_BIT_POSITION,
+      (self.data & ~RESERVE_FACTOR_MASK) >> RESERVE_FACTOR_START_BIT_POSITION
+    );
+  }
 
-    /**
-     * @dev Gets the configuration flags of the reserve from a memory object
-     * @param self The reserve configuration
-     * @return The state flags representing active, frozen, borrowing enabled, stableRateBorrowing enabled
-     *
-     */
-    function getFlagsMemory(DataTypes.ReserveConfigurationMap memory self)
-        internal
-        pure
-        returns (bool, bool, bool, bool)
-    {
-        return (
-            (self.data & ~ACTIVE_MASK) != 0,
-            (self.data & ~FROZEN_MASK) != 0,
-            (self.data & ~BORROWING_MASK) != 0,
-            (self.data & ~STABLE_BORROWING_MASK) != 0
-        );
-    }
+  /**
+   * @dev Gets the configuration flags of the reserve from a memory object
+   * @param self The reserve configuration
+   * @return The state flags representing active, frozen, borrowing enabled, stableRateBorrowing enabled
+   *
+   */
+  function getFlagsMemory(
+    DataTypes.ReserveConfigurationMap memory self
+  ) internal pure returns (bool, bool, bool, bool) {
+    return (
+      (self.data & ~ACTIVE_MASK) != 0,
+      (self.data & ~FROZEN_MASK) != 0,
+      (self.data & ~BORROWING_MASK) != 0,
+      (self.data & ~STABLE_BORROWING_MASK) != 0
+    );
+  }
 }
 
 /**
@@ -328,100 +363,100 @@ library ReserveConfiguration {
  *  - P = Pausable
  */
 library Errors {
-    //common errors
-    string public constant CALLER_NOT_POOL_ADMIN = "33"; // 'The caller must be the pool admin'
-    string public constant BORROW_ALLOWANCE_NOT_ENOUGH = "59"; // User borrows on behalf, but allowance are too small
+  //common errors
+  string public constant CALLER_NOT_POOL_ADMIN = '33'; // 'The caller must be the pool admin'
+  string public constant BORROW_ALLOWANCE_NOT_ENOUGH = '59'; // User borrows on behalf, but allowance are too small
 
-    //contract specific errors
-    string public constant VL_INVALID_AMOUNT = "1"; // 'Amount must be greater than 0'
-    string public constant VL_NO_ACTIVE_RESERVE = "2"; // 'Action requires an active reserve'
-    string public constant VL_RESERVE_FROZEN = "3"; // 'Action cannot be performed because the reserve is frozen'
-    string public constant VL_CURRENT_AVAILABLE_LIQUIDITY_NOT_ENOUGH = "4"; // 'The current liquidity is not enough'
-    string public constant VL_NOT_ENOUGH_AVAILABLE_USER_BALANCE = "5"; // 'User cannot withdraw more than the available balance'
-    string public constant VL_TRANSFER_NOT_ALLOWED = "6"; // 'Transfer cannot be allowed.'
-    string public constant VL_BORROWING_NOT_ENABLED = "7"; // 'Borrowing is not enabled'
-    string public constant VL_INVALID_INTEREST_RATE_MODE_SELECTED = "8"; // 'Invalid interest rate mode selected'
-    string public constant VL_COLLATERAL_BALANCE_IS_0 = "9"; // 'The collateral balance is 0'
-    string public constant VL_HEALTH_FACTOR_LOWER_THAN_LIQUIDATION_THRESHOLD = "10"; // 'Health factor is lesser than the liquidation threshold'
-    string public constant VL_COLLATERAL_CANNOT_COVER_NEW_BORROW = "11"; // 'There is not enough collateral to cover a new borrow'
-    string public constant VL_STABLE_BORROWING_NOT_ENABLED = "12"; // stable borrowing not enabled
-    string public constant VL_COLLATERAL_SAME_AS_BORROWING_CURRENCY = "13"; // collateral is (mostly) the same currency that is being borrowed
-    string public constant VL_AMOUNT_BIGGER_THAN_MAX_LOAN_SIZE_STABLE = "14"; // 'The requested amount is greater than the max loan size in stable rate mode
-    string public constant VL_NO_DEBT_OF_SELECTED_TYPE = "15"; // 'for repayment of stable debt, the user needs to have stable debt, otherwise, he needs to have variable debt'
-    string public constant VL_NO_EXPLICIT_AMOUNT_TO_REPAY_ON_BEHALF = "16"; // 'To repay on behalf of an user an explicit amount to repay is needed'
-    string public constant VL_NO_STABLE_RATE_LOAN_IN_RESERVE = "17"; // 'User does not have a stable rate loan in progress on this reserve'
-    string public constant VL_NO_VARIABLE_RATE_LOAN_IN_RESERVE = "18"; // 'User does not have a variable rate loan in progress on this reserve'
-    string public constant VL_UNDERLYING_BALANCE_NOT_GREATER_THAN_0 = "19"; // 'The underlying balance needs to be greater than 0'
-    string public constant VL_DEPOSIT_ALREADY_IN_USE = "20"; // 'User deposit is already being used as collateral'
-    string public constant LP_NOT_ENOUGH_STABLE_BORROW_BALANCE = "21"; // 'User does not have any stable rate loan for this reserve'
-    string public constant LP_INTEREST_RATE_REBALANCE_CONDITIONS_NOT_MET = "22"; // 'Interest rate rebalance conditions were not met'
-    string public constant LP_LIQUIDATION_CALL_FAILED = "23"; // 'Liquidation call failed'
-    string public constant LP_NOT_ENOUGH_LIQUIDITY_TO_BORROW = "24"; // 'There is not enough liquidity available to borrow'
-    string public constant LP_REQUESTED_AMOUNT_TOO_SMALL = "25"; // 'The requested amount is too small for a FlashLoan.'
-    string public constant LP_INCONSISTENT_PROTOCOL_ACTUAL_BALANCE = "26"; // 'The actual balance of the protocol is inconsistent'
-    string public constant LP_CALLER_NOT_LENDING_POOL_CONFIGURATOR = "27"; // 'The caller of the function is not the lending pool configurator'
-    string public constant LP_INCONSISTENT_FLASHLOAN_PARAMS = "28";
-    string public constant CT_CALLER_MUST_BE_LENDING_POOL = "29"; // 'The caller of this function must be a lending pool'
-    string public constant CT_CANNOT_GIVE_ALLOWANCE_TO_HIMSELF = "30"; // 'User cannot give allowance to himself'
-    string public constant CT_TRANSFER_AMOUNT_NOT_GT_0 = "31"; // 'Transferred amount needs to be greater than zero'
-    string public constant RL_RESERVE_ALREADY_INITIALIZED = "32"; // 'Reserve has already been initialized'
-    string public constant LPC_RESERVE_LIQUIDITY_NOT_0 = "34"; // 'The liquidity of the reserve needs to be 0'
-    string public constant LPC_INVALID_ATOKEN_POOL_ADDRESS = "35"; // 'The liquidity of the reserve needs to be 0'
-    string public constant LPC_INVALID_STABLE_DEBT_TOKEN_POOL_ADDRESS = "36"; // 'The liquidity of the reserve needs to be 0'
-    string public constant LPC_INVALID_VARIABLE_DEBT_TOKEN_POOL_ADDRESS = "37"; // 'The liquidity of the reserve needs to be 0'
-    string public constant LPC_INVALID_STABLE_DEBT_TOKEN_UNDERLYING_ADDRESS = "38"; // 'The liquidity of the reserve needs to be 0'
-    string public constant LPC_INVALID_VARIABLE_DEBT_TOKEN_UNDERLYING_ADDRESS = "39"; // 'The liquidity of the reserve needs to be 0'
-    string public constant LPC_INVALID_ADDRESSES_PROVIDER_ID = "40"; // 'The liquidity of the reserve needs to be 0'
-    string public constant LPC_INVALID_CONFIGURATION = "75"; // 'Invalid risk parameters for the reserve'
-    string public constant LPC_CALLER_NOT_EMERGENCY_ADMIN = "76"; // 'The caller must be the emergency admin'
-    string public constant LPAPR_PROVIDER_NOT_REGISTERED = "41"; // 'Provider is not registered'
-    string public constant LPCM_HEALTH_FACTOR_NOT_BELOW_THRESHOLD = "42"; // 'Health factor is not below the threshold'
-    string public constant LPCM_COLLATERAL_CANNOT_BE_LIQUIDATED = "43"; // 'The collateral chosen cannot be liquidated'
-    string public constant LPCM_SPECIFIED_CURRENCY_NOT_BORROWED_BY_USER = "44"; // 'User did not borrow the specified currency'
-    string public constant LPCM_NOT_ENOUGH_LIQUIDITY_TO_LIQUIDATE = "45"; // "There isn't enough liquidity available to liquidate"
-    string public constant LPCM_NO_ERRORS = "46"; // 'No errors'
-    string public constant LP_INVALID_FLASHLOAN_MODE = "47"; //Invalid flashloan mode selected
-    string public constant MATH_MULTIPLICATION_OVERFLOW = "48";
-    string public constant MATH_ADDITION_OVERFLOW = "49";
-    string public constant MATH_DIVISION_BY_ZERO = "50";
-    string public constant RL_LIQUIDITY_INDEX_OVERFLOW = "51"; //  Liquidity index overflows uint128
-    string public constant RL_VARIABLE_BORROW_INDEX_OVERFLOW = "52"; //  Variable borrow index overflows uint128
-    string public constant RL_LIQUIDITY_RATE_OVERFLOW = "53"; //  Liquidity rate overflows uint128
-    string public constant RL_VARIABLE_BORROW_RATE_OVERFLOW = "54"; //  Variable borrow rate overflows uint128
-    string public constant RL_STABLE_BORROW_RATE_OVERFLOW = "55"; //  Stable borrow rate overflows uint128
-    string public constant CT_INVALID_MINT_AMOUNT = "56"; //invalid amount to mint
-    string public constant LP_FAILED_REPAY_WITH_COLLATERAL = "57";
-    string public constant CT_INVALID_BURN_AMOUNT = "58"; //invalid amount to burn
-    string public constant LP_FAILED_COLLATERAL_SWAP = "60";
-    string public constant LP_INVALID_EQUAL_ASSETS_TO_SWAP = "61";
-    string public constant LP_REENTRANCY_NOT_ALLOWED = "62";
-    string public constant LP_CALLER_MUST_BE_AN_ATOKEN = "63";
-    string public constant LP_IS_PAUSED = "64"; // 'Pool is paused'
-    string public constant LP_NO_MORE_RESERVES_ALLOWED = "65";
-    string public constant LP_INVALID_FLASH_LOAN_EXECUTOR_RETURN = "66";
-    string public constant RC_INVALID_LTV = "67";
-    string public constant RC_INVALID_LIQ_THRESHOLD = "68";
-    string public constant RC_INVALID_LIQ_BONUS = "69";
-    string public constant RC_INVALID_DECIMALS = "70";
-    string public constant RC_INVALID_RESERVE_FACTOR = "71";
-    string public constant LPAPR_INVALID_ADDRESSES_PROVIDER_ID = "72";
-    string public constant VL_INCONSISTENT_FLASHLOAN_PARAMS = "73";
-    string public constant LP_INCONSISTENT_PARAMS_LENGTH = "74";
-    string public constant UL_INVALID_INDEX = "77";
-    string public constant LP_NOT_CONTRACT = "78";
-    string public constant SDT_STABLE_DEBT_OVERFLOW = "79";
-    string public constant SDT_BURN_EXCEEDS_BALANCE = "80";
+  //contract specific errors
+  string public constant VL_INVALID_AMOUNT = '1'; // 'Amount must be greater than 0'
+  string public constant VL_NO_ACTIVE_RESERVE = '2'; // 'Action requires an active reserve'
+  string public constant VL_RESERVE_FROZEN = '3'; // 'Action cannot be performed because the reserve is frozen'
+  string public constant VL_CURRENT_AVAILABLE_LIQUIDITY_NOT_ENOUGH = '4'; // 'The current liquidity is not enough'
+  string public constant VL_NOT_ENOUGH_AVAILABLE_USER_BALANCE = '5'; // 'User cannot withdraw more than the available balance'
+  string public constant VL_TRANSFER_NOT_ALLOWED = '6'; // 'Transfer cannot be allowed.'
+  string public constant VL_BORROWING_NOT_ENABLED = '7'; // 'Borrowing is not enabled'
+  string public constant VL_INVALID_INTEREST_RATE_MODE_SELECTED = '8'; // 'Invalid interest rate mode selected'
+  string public constant VL_COLLATERAL_BALANCE_IS_0 = '9'; // 'The collateral balance is 0'
+  string public constant VL_HEALTH_FACTOR_LOWER_THAN_LIQUIDATION_THRESHOLD = '10'; // 'Health factor is lesser than the liquidation threshold'
+  string public constant VL_COLLATERAL_CANNOT_COVER_NEW_BORROW = '11'; // 'There is not enough collateral to cover a new borrow'
+  string public constant VL_STABLE_BORROWING_NOT_ENABLED = '12'; // stable borrowing not enabled
+  string public constant VL_COLLATERAL_SAME_AS_BORROWING_CURRENCY = '13'; // collateral is (mostly) the same currency that is being borrowed
+  string public constant VL_AMOUNT_BIGGER_THAN_MAX_LOAN_SIZE_STABLE = '14'; // 'The requested amount is greater than the max loan size in stable rate mode
+  string public constant VL_NO_DEBT_OF_SELECTED_TYPE = '15'; // 'for repayment of stable debt, the user needs to have stable debt, otherwise, he needs to have variable debt'
+  string public constant VL_NO_EXPLICIT_AMOUNT_TO_REPAY_ON_BEHALF = '16'; // 'To repay on behalf of an user an explicit amount to repay is needed'
+  string public constant VL_NO_STABLE_RATE_LOAN_IN_RESERVE = '17'; // 'User does not have a stable rate loan in progress on this reserve'
+  string public constant VL_NO_VARIABLE_RATE_LOAN_IN_RESERVE = '18'; // 'User does not have a variable rate loan in progress on this reserve'
+  string public constant VL_UNDERLYING_BALANCE_NOT_GREATER_THAN_0 = '19'; // 'The underlying balance needs to be greater than 0'
+  string public constant VL_DEPOSIT_ALREADY_IN_USE = '20'; // 'User deposit is already being used as collateral'
+  string public constant LP_NOT_ENOUGH_STABLE_BORROW_BALANCE = '21'; // 'User does not have any stable rate loan for this reserve'
+  string public constant LP_INTEREST_RATE_REBALANCE_CONDITIONS_NOT_MET = '22'; // 'Interest rate rebalance conditions were not met'
+  string public constant LP_LIQUIDATION_CALL_FAILED = '23'; // 'Liquidation call failed'
+  string public constant LP_NOT_ENOUGH_LIQUIDITY_TO_BORROW = '24'; // 'There is not enough liquidity available to borrow'
+  string public constant LP_REQUESTED_AMOUNT_TOO_SMALL = '25'; // 'The requested amount is too small for a FlashLoan.'
+  string public constant LP_INCONSISTENT_PROTOCOL_ACTUAL_BALANCE = '26'; // 'The actual balance of the protocol is inconsistent'
+  string public constant LP_CALLER_NOT_LENDING_POOL_CONFIGURATOR = '27'; // 'The caller of the function is not the lending pool configurator'
+  string public constant LP_INCONSISTENT_FLASHLOAN_PARAMS = '28';
+  string public constant CT_CALLER_MUST_BE_LENDING_POOL = '29'; // 'The caller of this function must be a lending pool'
+  string public constant CT_CANNOT_GIVE_ALLOWANCE_TO_HIMSELF = '30'; // 'User cannot give allowance to himself'
+  string public constant CT_TRANSFER_AMOUNT_NOT_GT_0 = '31'; // 'Transferred amount needs to be greater than zero'
+  string public constant RL_RESERVE_ALREADY_INITIALIZED = '32'; // 'Reserve has already been initialized'
+  string public constant LPC_RESERVE_LIQUIDITY_NOT_0 = '34'; // 'The liquidity of the reserve needs to be 0'
+  string public constant LPC_INVALID_ATOKEN_POOL_ADDRESS = '35'; // 'The liquidity of the reserve needs to be 0'
+  string public constant LPC_INVALID_STABLE_DEBT_TOKEN_POOL_ADDRESS = '36'; // 'The liquidity of the reserve needs to be 0'
+  string public constant LPC_INVALID_VARIABLE_DEBT_TOKEN_POOL_ADDRESS = '37'; // 'The liquidity of the reserve needs to be 0'
+  string public constant LPC_INVALID_STABLE_DEBT_TOKEN_UNDERLYING_ADDRESS = '38'; // 'The liquidity of the reserve needs to be 0'
+  string public constant LPC_INVALID_VARIABLE_DEBT_TOKEN_UNDERLYING_ADDRESS = '39'; // 'The liquidity of the reserve needs to be 0'
+  string public constant LPC_INVALID_ADDRESSES_PROVIDER_ID = '40'; // 'The liquidity of the reserve needs to be 0'
+  string public constant LPC_INVALID_CONFIGURATION = '75'; // 'Invalid risk parameters for the reserve'
+  string public constant LPC_CALLER_NOT_EMERGENCY_ADMIN = '76'; // 'The caller must be the emergency admin'
+  string public constant LPAPR_PROVIDER_NOT_REGISTERED = '41'; // 'Provider is not registered'
+  string public constant LPCM_HEALTH_FACTOR_NOT_BELOW_THRESHOLD = '42'; // 'Health factor is not below the threshold'
+  string public constant LPCM_COLLATERAL_CANNOT_BE_LIQUIDATED = '43'; // 'The collateral chosen cannot be liquidated'
+  string public constant LPCM_SPECIFIED_CURRENCY_NOT_BORROWED_BY_USER = '44'; // 'User did not borrow the specified currency'
+  string public constant LPCM_NOT_ENOUGH_LIQUIDITY_TO_LIQUIDATE = '45'; // "There isn't enough liquidity available to liquidate"
+  string public constant LPCM_NO_ERRORS = '46'; // 'No errors'
+  string public constant LP_INVALID_FLASHLOAN_MODE = '47'; //Invalid flashloan mode selected
+  string public constant MATH_MULTIPLICATION_OVERFLOW = '48';
+  string public constant MATH_ADDITION_OVERFLOW = '49';
+  string public constant MATH_DIVISION_BY_ZERO = '50';
+  string public constant RL_LIQUIDITY_INDEX_OVERFLOW = '51'; //  Liquidity index overflows uint128
+  string public constant RL_VARIABLE_BORROW_INDEX_OVERFLOW = '52'; //  Variable borrow index overflows uint128
+  string public constant RL_LIQUIDITY_RATE_OVERFLOW = '53'; //  Liquidity rate overflows uint128
+  string public constant RL_VARIABLE_BORROW_RATE_OVERFLOW = '54'; //  Variable borrow rate overflows uint128
+  string public constant RL_STABLE_BORROW_RATE_OVERFLOW = '55'; //  Stable borrow rate overflows uint128
+  string public constant CT_INVALID_MINT_AMOUNT = '56'; //invalid amount to mint
+  string public constant LP_FAILED_REPAY_WITH_COLLATERAL = '57';
+  string public constant CT_INVALID_BURN_AMOUNT = '58'; //invalid amount to burn
+  string public constant LP_FAILED_COLLATERAL_SWAP = '60';
+  string public constant LP_INVALID_EQUAL_ASSETS_TO_SWAP = '61';
+  string public constant LP_REENTRANCY_NOT_ALLOWED = '62';
+  string public constant LP_CALLER_MUST_BE_AN_ATOKEN = '63';
+  string public constant LP_IS_PAUSED = '64'; // 'Pool is paused'
+  string public constant LP_NO_MORE_RESERVES_ALLOWED = '65';
+  string public constant LP_INVALID_FLASH_LOAN_EXECUTOR_RETURN = '66';
+  string public constant RC_INVALID_LTV = '67';
+  string public constant RC_INVALID_LIQ_THRESHOLD = '68';
+  string public constant RC_INVALID_LIQ_BONUS = '69';
+  string public constant RC_INVALID_DECIMALS = '70';
+  string public constant RC_INVALID_RESERVE_FACTOR = '71';
+  string public constant LPAPR_INVALID_ADDRESSES_PROVIDER_ID = '72';
+  string public constant VL_INCONSISTENT_FLASHLOAN_PARAMS = '73';
+  string public constant LP_INCONSISTENT_PARAMS_LENGTH = '74';
+  string public constant UL_INVALID_INDEX = '77';
+  string public constant LP_NOT_CONTRACT = '78';
+  string public constant SDT_STABLE_DEBT_OVERFLOW = '79';
+  string public constant SDT_BURN_EXCEEDS_BALANCE = '80';
 
-    enum CollateralManagerErrors {
-        NO_ERROR,
-        NO_COLLATERAL_AVAILABLE,
-        COLLATERAL_CANNOT_BE_LIQUIDATED,
-        CURRRENCY_NOT_BORROWED,
-        HEALTH_FACTOR_ABOVE_THRESHOLD,
-        NOT_ENOUGH_LIQUIDITY,
-        NO_ACTIVE_RESERVE,
-        HEALTH_FACTOR_LOWER_THAN_LIQUIDATION_THRESHOLD,
-        INVALID_EQUAL_ASSETS_TO_SWAP,
-        FROZEN_RESERVE
-    }
+  enum CollateralManagerErrors {
+    NO_ERROR,
+    NO_COLLATERAL_AVAILABLE,
+    COLLATERAL_CANNOT_BE_LIQUIDATED,
+    CURRRENCY_NOT_BORROWED,
+    HEALTH_FACTOR_ABOVE_THRESHOLD,
+    NOT_ENOUGH_LIQUIDITY,
+    NO_ACTIVE_RESERVE,
+    HEALTH_FACTOR_LOWER_THAN_LIQUIDATION_THRESHOLD,
+    INVALID_EQUAL_ASSETS_TO_SWAP,
+    FROZEN_RESERVE
+  }
 }

--- a/src/v2-config-engine/protocol-v2/ReserveConfiguration.sol
+++ b/src/v2-config-engine/protocol-v2/ReserveConfiguration.sol
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.12;
+
+import {DataTypes} from "aave-address-book/AaveV2.sol";
+
+/**
+ * @title ReserveConfiguration library
+ * @author Aave
+ * @notice Implements the bitmap logic to handle the reserve configuration
+ */
+library ReserveConfiguration {
+    uint256 constant LTV_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000; // prettier-ignore
+    uint256 constant LIQUIDATION_THRESHOLD_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000FFFF; // prettier-ignore
+    uint256 constant LIQUIDATION_BONUS_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000FFFFFFFF; // prettier-ignore
+    uint256 constant DECIMALS_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00FFFFFFFFFFFF; // prettier-ignore
+    uint256 constant ACTIVE_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFFFFFFFFFF; // prettier-ignore
+    uint256 constant FROZEN_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFDFFFFFFFFFFFFFF; // prettier-ignore
+    uint256 constant BORROWING_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFF; // prettier-ignore
+    uint256 constant STABLE_BORROWING_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7FFFFFFFFFFFFFF; // prettier-ignore
+    uint256 constant RESERVE_FACTOR_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000FFFFFFFFFFFFFFFF; // prettier-ignore
+
+    /// @dev For the LTV, the start bit is 0 (up to 15), hence no bitshifting is needed
+    uint256 constant LIQUIDATION_THRESHOLD_START_BIT_POSITION = 16;
+    uint256 constant LIQUIDATION_BONUS_START_BIT_POSITION = 32;
+    uint256 constant RESERVE_DECIMALS_START_BIT_POSITION = 48;
+    uint256 constant IS_ACTIVE_START_BIT_POSITION = 56;
+    uint256 constant IS_FROZEN_START_BIT_POSITION = 57;
+    uint256 constant BORROWING_ENABLED_START_BIT_POSITION = 58;
+    uint256 constant STABLE_BORROWING_ENABLED_START_BIT_POSITION = 59;
+    uint256 constant RESERVE_FACTOR_START_BIT_POSITION = 64;
+
+    uint256 constant MAX_VALID_LTV = 65535;
+    uint256 constant MAX_VALID_LIQUIDATION_THRESHOLD = 65535;
+    uint256 constant MAX_VALID_LIQUIDATION_BONUS = 65535;
+    uint256 constant MAX_VALID_DECIMALS = 255;
+    uint256 constant MAX_VALID_RESERVE_FACTOR = 65535;
+
+    /**
+     * @dev Sets the Loan to Value of the reserve
+     * @param self The reserve configuration
+     * @param ltv the new ltv
+     *
+     */
+    function setLtv(DataTypes.ReserveConfigurationMap memory self, uint256 ltv) internal pure {
+        require(ltv <= MAX_VALID_LTV, Errors.RC_INVALID_LTV);
+
+        self.data = (self.data & LTV_MASK) | ltv;
+    }
+
+    /**
+     * @dev Gets the Loan to Value of the reserve
+     * @param self The reserve configuration
+     * @return The loan to value
+     *
+     */
+    function getLtv(DataTypes.ReserveConfigurationMap storage self) internal view returns (uint256) {
+        return self.data & ~LTV_MASK;
+    }
+
+    /**
+     * @dev Sets the liquidation threshold of the reserve
+     * @param self The reserve configuration
+     * @param threshold The new liquidation threshold
+     *
+     */
+    function setLiquidationThreshold(DataTypes.ReserveConfigurationMap memory self, uint256 threshold) internal pure {
+        require(threshold <= MAX_VALID_LIQUIDATION_THRESHOLD, Errors.RC_INVALID_LIQ_THRESHOLD);
+
+        self.data = (self.data & LIQUIDATION_THRESHOLD_MASK) | (threshold << LIQUIDATION_THRESHOLD_START_BIT_POSITION);
+    }
+
+    /**
+     * @dev Gets the liquidation threshold of the reserve
+     * @param self The reserve configuration
+     * @return The liquidation threshold
+     *
+     */
+    function getLiquidationThreshold(DataTypes.ReserveConfigurationMap storage self) internal view returns (uint256) {
+        return (self.data & ~LIQUIDATION_THRESHOLD_MASK) >> LIQUIDATION_THRESHOLD_START_BIT_POSITION;
+    }
+
+    /**
+     * @dev Sets the liquidation bonus of the reserve
+     * @param self The reserve configuration
+     * @param bonus The new liquidation bonus
+     *
+     */
+    function setLiquidationBonus(DataTypes.ReserveConfigurationMap memory self, uint256 bonus) internal pure {
+        require(bonus <= MAX_VALID_LIQUIDATION_BONUS, Errors.RC_INVALID_LIQ_BONUS);
+
+        self.data = (self.data & LIQUIDATION_BONUS_MASK) | (bonus << LIQUIDATION_BONUS_START_BIT_POSITION);
+    }
+
+    /**
+     * @dev Gets the liquidation bonus of the reserve
+     * @param self The reserve configuration
+     * @return The liquidation bonus
+     *
+     */
+    function getLiquidationBonus(DataTypes.ReserveConfigurationMap storage self) internal view returns (uint256) {
+        return (self.data & ~LIQUIDATION_BONUS_MASK) >> LIQUIDATION_BONUS_START_BIT_POSITION;
+    }
+
+    /**
+     * @dev Sets the decimals of the underlying asset of the reserve
+     * @param self The reserve configuration
+     * @param decimals The decimals
+     *
+     */
+    function setDecimals(DataTypes.ReserveConfigurationMap memory self, uint256 decimals) internal pure {
+        require(decimals <= MAX_VALID_DECIMALS, Errors.RC_INVALID_DECIMALS);
+
+        self.data = (self.data & DECIMALS_MASK) | (decimals << RESERVE_DECIMALS_START_BIT_POSITION);
+    }
+
+    /**
+     * @dev Gets the decimals of the underlying asset of the reserve
+     * @param self The reserve configuration
+     * @return The decimals of the asset
+     *
+     */
+    function getDecimals(DataTypes.ReserveConfigurationMap storage self) internal view returns (uint256) {
+        return (self.data & ~DECIMALS_MASK) >> RESERVE_DECIMALS_START_BIT_POSITION;
+    }
+
+    /**
+     * @dev Sets the active state of the reserve
+     * @param self The reserve configuration
+     * @param active The active state
+     *
+     */
+    function setActive(DataTypes.ReserveConfigurationMap memory self, bool active) internal pure {
+        self.data = (self.data & ACTIVE_MASK) | (uint256(active ? 1 : 0) << IS_ACTIVE_START_BIT_POSITION);
+    }
+
+    /**
+     * @dev Gets the active state of the reserve
+     * @param self The reserve configuration
+     * @return The active state
+     *
+     */
+    function getActive(DataTypes.ReserveConfigurationMap storage self) internal view returns (bool) {
+        return (self.data & ~ACTIVE_MASK) != 0;
+    }
+
+    /**
+     * @dev Sets the frozen state of the reserve
+     * @param self The reserve configuration
+     * @param frozen The frozen state
+     *
+     */
+    function setFrozen(DataTypes.ReserveConfigurationMap memory self, bool frozen) internal pure {
+        self.data = (self.data & FROZEN_MASK) | (uint256(frozen ? 1 : 0) << IS_FROZEN_START_BIT_POSITION);
+    }
+
+    /**
+     * @dev Gets the frozen state of the reserve
+     * @param self The reserve configuration
+     * @return The frozen state
+     *
+     */
+    function getFrozen(DataTypes.ReserveConfigurationMap storage self) internal view returns (bool) {
+        return (self.data & ~FROZEN_MASK) != 0;
+    }
+
+    /**
+     * @dev Enables or disables borrowing on the reserve
+     * @param self The reserve configuration
+     * @param enabled True if the borrowing needs to be enabled, false otherwise
+     *
+     */
+    function setBorrowingEnabled(DataTypes.ReserveConfigurationMap memory self, bool enabled) internal pure {
+        self.data = (self.data & BORROWING_MASK) | (uint256(enabled ? 1 : 0) << BORROWING_ENABLED_START_BIT_POSITION);
+    }
+
+    /**
+     * @dev Gets the borrowing state of the reserve
+     * @param self The reserve configuration
+     * @return The borrowing state
+     *
+     */
+    function getBorrowingEnabled(DataTypes.ReserveConfigurationMap storage self) internal view returns (bool) {
+        return (self.data & ~BORROWING_MASK) != 0;
+    }
+
+    /**
+     * @dev Enables or disables stable rate borrowing on the reserve
+     * @param self The reserve configuration
+     * @param enabled True if the stable rate borrowing needs to be enabled, false otherwise
+     *
+     */
+    function setStableRateBorrowingEnabled(DataTypes.ReserveConfigurationMap memory self, bool enabled) internal pure {
+        self.data = (self.data & STABLE_BORROWING_MASK)
+            | (uint256(enabled ? 1 : 0) << STABLE_BORROWING_ENABLED_START_BIT_POSITION);
+    }
+
+    /**
+     * @dev Gets the stable rate borrowing state of the reserve
+     * @param self The reserve configuration
+     * @return The stable rate borrowing state
+     *
+     */
+    function getStableRateBorrowingEnabled(DataTypes.ReserveConfigurationMap storage self)
+        internal
+        view
+        returns (bool)
+    {
+        return (self.data & ~STABLE_BORROWING_MASK) != 0;
+    }
+
+    /**
+     * @dev Sets the reserve factor of the reserve
+     * @param self The reserve configuration
+     * @param reserveFactor The reserve factor
+     *
+     */
+    function setReserveFactor(DataTypes.ReserveConfigurationMap memory self, uint256 reserveFactor) internal pure {
+        require(reserveFactor <= MAX_VALID_RESERVE_FACTOR, Errors.RC_INVALID_RESERVE_FACTOR);
+
+        self.data = (self.data & RESERVE_FACTOR_MASK) | (reserveFactor << RESERVE_FACTOR_START_BIT_POSITION);
+    }
+
+    /**
+     * @dev Gets the reserve factor of the reserve
+     * @param self The reserve configuration
+     * @return The reserve factor
+     *
+     */
+    function getReserveFactor(DataTypes.ReserveConfigurationMap storage self) internal view returns (uint256) {
+        return (self.data & ~RESERVE_FACTOR_MASK) >> RESERVE_FACTOR_START_BIT_POSITION;
+    }
+
+    /**
+     * @dev Gets the configuration flags of the reserve
+     * @param self The reserve configuration
+     * @return The state flags representing active, frozen, borrowing enabled, stableRateBorrowing enabled
+     *
+     */
+    function getFlags(DataTypes.ReserveConfigurationMap memory self) internal pure returns (bool, bool, bool, bool) {
+        uint256 dataLocal = self.data;
+
+        return (
+            (dataLocal & ~ACTIVE_MASK) != 0,
+            (dataLocal & ~FROZEN_MASK) != 0,
+            (dataLocal & ~BORROWING_MASK) != 0,
+            (dataLocal & ~STABLE_BORROWING_MASK) != 0
+        );
+    }
+
+    /**
+     * @dev Gets the configuration paramters of the reserve
+     * @param self The reserve configuration
+     * @return The state params representing ltv, liquidation threshold, liquidation bonus, the reserve decimals
+     *
+     */
+    function getParams(DataTypes.ReserveConfigurationMap memory self)
+        internal
+        pure
+        returns (uint256, uint256, uint256, uint256, uint256)
+    {
+        uint256 dataLocal = self.data;
+
+        return (
+            dataLocal & ~LTV_MASK,
+            (dataLocal & ~LIQUIDATION_THRESHOLD_MASK) >> LIQUIDATION_THRESHOLD_START_BIT_POSITION,
+            (dataLocal & ~LIQUIDATION_BONUS_MASK) >> LIQUIDATION_BONUS_START_BIT_POSITION,
+            (dataLocal & ~DECIMALS_MASK) >> RESERVE_DECIMALS_START_BIT_POSITION,
+            (dataLocal & ~RESERVE_FACTOR_MASK) >> RESERVE_FACTOR_START_BIT_POSITION
+        );
+    }
+
+    /**
+     * @dev Gets the configuration paramters of the reserve from a memory object
+     * @param self The reserve configuration
+     * @return The state params representing ltv, liquidation threshold, liquidation bonus, the reserve decimals
+     *
+     */
+    function getParamsMemory(DataTypes.ReserveConfigurationMap memory self)
+        internal
+        pure
+        returns (uint256, uint256, uint256, uint256, uint256)
+    {
+        return (
+            self.data & ~LTV_MASK,
+            (self.data & ~LIQUIDATION_THRESHOLD_MASK) >> LIQUIDATION_THRESHOLD_START_BIT_POSITION,
+            (self.data & ~LIQUIDATION_BONUS_MASK) >> LIQUIDATION_BONUS_START_BIT_POSITION,
+            (self.data & ~DECIMALS_MASK) >> RESERVE_DECIMALS_START_BIT_POSITION,
+            (self.data & ~RESERVE_FACTOR_MASK) >> RESERVE_FACTOR_START_BIT_POSITION
+        );
+    }
+
+    /**
+     * @dev Gets the configuration flags of the reserve from a memory object
+     * @param self The reserve configuration
+     * @return The state flags representing active, frozen, borrowing enabled, stableRateBorrowing enabled
+     *
+     */
+    function getFlagsMemory(DataTypes.ReserveConfigurationMap memory self)
+        internal
+        pure
+        returns (bool, bool, bool, bool)
+    {
+        return (
+            (self.data & ~ACTIVE_MASK) != 0,
+            (self.data & ~FROZEN_MASK) != 0,
+            (self.data & ~BORROWING_MASK) != 0,
+            (self.data & ~STABLE_BORROWING_MASK) != 0
+        );
+    }
+}
+
+/**
+ * @title Errors library
+ * @author Aave
+ * @notice Defines the error messages emitted by the different contracts of the Aave protocol
+ * @dev Error messages prefix glossary:
+ *  - VL = ValidationLogic
+ *  - MATH = Math libraries
+ *  - CT = Common errors between tokens (AToken, VariableDebtToken and StableDebtToken)
+ *  - AT = AToken
+ *  - SDT = StableDebtToken
+ *  - VDT = VariableDebtToken
+ *  - LP = LendingPool
+ *  - LPAPR = LendingPoolAddressesProviderRegistry
+ *  - LPC = LendingPoolConfiguration
+ *  - RL = ReserveLogic
+ *  - LPCM = LendingPoolCollateralManager
+ *  - P = Pausable
+ */
+library Errors {
+    //common errors
+    string public constant CALLER_NOT_POOL_ADMIN = "33"; // 'The caller must be the pool admin'
+    string public constant BORROW_ALLOWANCE_NOT_ENOUGH = "59"; // User borrows on behalf, but allowance are too small
+
+    //contract specific errors
+    string public constant VL_INVALID_AMOUNT = "1"; // 'Amount must be greater than 0'
+    string public constant VL_NO_ACTIVE_RESERVE = "2"; // 'Action requires an active reserve'
+    string public constant VL_RESERVE_FROZEN = "3"; // 'Action cannot be performed because the reserve is frozen'
+    string public constant VL_CURRENT_AVAILABLE_LIQUIDITY_NOT_ENOUGH = "4"; // 'The current liquidity is not enough'
+    string public constant VL_NOT_ENOUGH_AVAILABLE_USER_BALANCE = "5"; // 'User cannot withdraw more than the available balance'
+    string public constant VL_TRANSFER_NOT_ALLOWED = "6"; // 'Transfer cannot be allowed.'
+    string public constant VL_BORROWING_NOT_ENABLED = "7"; // 'Borrowing is not enabled'
+    string public constant VL_INVALID_INTEREST_RATE_MODE_SELECTED = "8"; // 'Invalid interest rate mode selected'
+    string public constant VL_COLLATERAL_BALANCE_IS_0 = "9"; // 'The collateral balance is 0'
+    string public constant VL_HEALTH_FACTOR_LOWER_THAN_LIQUIDATION_THRESHOLD = "10"; // 'Health factor is lesser than the liquidation threshold'
+    string public constant VL_COLLATERAL_CANNOT_COVER_NEW_BORROW = "11"; // 'There is not enough collateral to cover a new borrow'
+    string public constant VL_STABLE_BORROWING_NOT_ENABLED = "12"; // stable borrowing not enabled
+    string public constant VL_COLLATERAL_SAME_AS_BORROWING_CURRENCY = "13"; // collateral is (mostly) the same currency that is being borrowed
+    string public constant VL_AMOUNT_BIGGER_THAN_MAX_LOAN_SIZE_STABLE = "14"; // 'The requested amount is greater than the max loan size in stable rate mode
+    string public constant VL_NO_DEBT_OF_SELECTED_TYPE = "15"; // 'for repayment of stable debt, the user needs to have stable debt, otherwise, he needs to have variable debt'
+    string public constant VL_NO_EXPLICIT_AMOUNT_TO_REPAY_ON_BEHALF = "16"; // 'To repay on behalf of an user an explicit amount to repay is needed'
+    string public constant VL_NO_STABLE_RATE_LOAN_IN_RESERVE = "17"; // 'User does not have a stable rate loan in progress on this reserve'
+    string public constant VL_NO_VARIABLE_RATE_LOAN_IN_RESERVE = "18"; // 'User does not have a variable rate loan in progress on this reserve'
+    string public constant VL_UNDERLYING_BALANCE_NOT_GREATER_THAN_0 = "19"; // 'The underlying balance needs to be greater than 0'
+    string public constant VL_DEPOSIT_ALREADY_IN_USE = "20"; // 'User deposit is already being used as collateral'
+    string public constant LP_NOT_ENOUGH_STABLE_BORROW_BALANCE = "21"; // 'User does not have any stable rate loan for this reserve'
+    string public constant LP_INTEREST_RATE_REBALANCE_CONDITIONS_NOT_MET = "22"; // 'Interest rate rebalance conditions were not met'
+    string public constant LP_LIQUIDATION_CALL_FAILED = "23"; // 'Liquidation call failed'
+    string public constant LP_NOT_ENOUGH_LIQUIDITY_TO_BORROW = "24"; // 'There is not enough liquidity available to borrow'
+    string public constant LP_REQUESTED_AMOUNT_TOO_SMALL = "25"; // 'The requested amount is too small for a FlashLoan.'
+    string public constant LP_INCONSISTENT_PROTOCOL_ACTUAL_BALANCE = "26"; // 'The actual balance of the protocol is inconsistent'
+    string public constant LP_CALLER_NOT_LENDING_POOL_CONFIGURATOR = "27"; // 'The caller of the function is not the lending pool configurator'
+    string public constant LP_INCONSISTENT_FLASHLOAN_PARAMS = "28";
+    string public constant CT_CALLER_MUST_BE_LENDING_POOL = "29"; // 'The caller of this function must be a lending pool'
+    string public constant CT_CANNOT_GIVE_ALLOWANCE_TO_HIMSELF = "30"; // 'User cannot give allowance to himself'
+    string public constant CT_TRANSFER_AMOUNT_NOT_GT_0 = "31"; // 'Transferred amount needs to be greater than zero'
+    string public constant RL_RESERVE_ALREADY_INITIALIZED = "32"; // 'Reserve has already been initialized'
+    string public constant LPC_RESERVE_LIQUIDITY_NOT_0 = "34"; // 'The liquidity of the reserve needs to be 0'
+    string public constant LPC_INVALID_ATOKEN_POOL_ADDRESS = "35"; // 'The liquidity of the reserve needs to be 0'
+    string public constant LPC_INVALID_STABLE_DEBT_TOKEN_POOL_ADDRESS = "36"; // 'The liquidity of the reserve needs to be 0'
+    string public constant LPC_INVALID_VARIABLE_DEBT_TOKEN_POOL_ADDRESS = "37"; // 'The liquidity of the reserve needs to be 0'
+    string public constant LPC_INVALID_STABLE_DEBT_TOKEN_UNDERLYING_ADDRESS = "38"; // 'The liquidity of the reserve needs to be 0'
+    string public constant LPC_INVALID_VARIABLE_DEBT_TOKEN_UNDERLYING_ADDRESS = "39"; // 'The liquidity of the reserve needs to be 0'
+    string public constant LPC_INVALID_ADDRESSES_PROVIDER_ID = "40"; // 'The liquidity of the reserve needs to be 0'
+    string public constant LPC_INVALID_CONFIGURATION = "75"; // 'Invalid risk parameters for the reserve'
+    string public constant LPC_CALLER_NOT_EMERGENCY_ADMIN = "76"; // 'The caller must be the emergency admin'
+    string public constant LPAPR_PROVIDER_NOT_REGISTERED = "41"; // 'Provider is not registered'
+    string public constant LPCM_HEALTH_FACTOR_NOT_BELOW_THRESHOLD = "42"; // 'Health factor is not below the threshold'
+    string public constant LPCM_COLLATERAL_CANNOT_BE_LIQUIDATED = "43"; // 'The collateral chosen cannot be liquidated'
+    string public constant LPCM_SPECIFIED_CURRENCY_NOT_BORROWED_BY_USER = "44"; // 'User did not borrow the specified currency'
+    string public constant LPCM_NOT_ENOUGH_LIQUIDITY_TO_LIQUIDATE = "45"; // "There isn't enough liquidity available to liquidate"
+    string public constant LPCM_NO_ERRORS = "46"; // 'No errors'
+    string public constant LP_INVALID_FLASHLOAN_MODE = "47"; //Invalid flashloan mode selected
+    string public constant MATH_MULTIPLICATION_OVERFLOW = "48";
+    string public constant MATH_ADDITION_OVERFLOW = "49";
+    string public constant MATH_DIVISION_BY_ZERO = "50";
+    string public constant RL_LIQUIDITY_INDEX_OVERFLOW = "51"; //  Liquidity index overflows uint128
+    string public constant RL_VARIABLE_BORROW_INDEX_OVERFLOW = "52"; //  Variable borrow index overflows uint128
+    string public constant RL_LIQUIDITY_RATE_OVERFLOW = "53"; //  Liquidity rate overflows uint128
+    string public constant RL_VARIABLE_BORROW_RATE_OVERFLOW = "54"; //  Variable borrow rate overflows uint128
+    string public constant RL_STABLE_BORROW_RATE_OVERFLOW = "55"; //  Stable borrow rate overflows uint128
+    string public constant CT_INVALID_MINT_AMOUNT = "56"; //invalid amount to mint
+    string public constant LP_FAILED_REPAY_WITH_COLLATERAL = "57";
+    string public constant CT_INVALID_BURN_AMOUNT = "58"; //invalid amount to burn
+    string public constant LP_FAILED_COLLATERAL_SWAP = "60";
+    string public constant LP_INVALID_EQUAL_ASSETS_TO_SWAP = "61";
+    string public constant LP_REENTRANCY_NOT_ALLOWED = "62";
+    string public constant LP_CALLER_MUST_BE_AN_ATOKEN = "63";
+    string public constant LP_IS_PAUSED = "64"; // 'Pool is paused'
+    string public constant LP_NO_MORE_RESERVES_ALLOWED = "65";
+    string public constant LP_INVALID_FLASH_LOAN_EXECUTOR_RETURN = "66";
+    string public constant RC_INVALID_LTV = "67";
+    string public constant RC_INVALID_LIQ_THRESHOLD = "68";
+    string public constant RC_INVALID_LIQ_BONUS = "69";
+    string public constant RC_INVALID_DECIMALS = "70";
+    string public constant RC_INVALID_RESERVE_FACTOR = "71";
+    string public constant LPAPR_INVALID_ADDRESSES_PROVIDER_ID = "72";
+    string public constant VL_INCONSISTENT_FLASHLOAN_PARAMS = "73";
+    string public constant LP_INCONSISTENT_PARAMS_LENGTH = "74";
+    string public constant UL_INVALID_INDEX = "77";
+    string public constant LP_NOT_CONTRACT = "78";
+    string public constant SDT_STABLE_DEBT_OVERFLOW = "79";
+    string public constant SDT_BURN_EXCEEDS_BALANCE = "80";
+
+    enum CollateralManagerErrors {
+        NO_ERROR,
+        NO_COLLATERAL_AVAILABLE,
+        COLLATERAL_CANNOT_BE_LIQUIDATED,
+        CURRRENCY_NOT_BORROWED,
+        HEALTH_FACTOR_ABOVE_THRESHOLD,
+        NOT_ENOUGH_LIQUIDITY,
+        NO_ACTIVE_RESERVE,
+        HEALTH_FACTOR_LOWER_THAN_LIQUIDATION_THRESHOLD,
+        INVALID_EQUAL_ASSETS_TO_SWAP,
+        FROZEN_RESERVE
+    }
+}


### PR DESCRIPTION
This pull requests adds the capability to the `AaveV2ConfigEngine`:

- listAssets()
- listAssetsCustom(...)
- updatePriceFeeds(...)
- updateCollateralSide(...)
- updateBorrowSide(...)

This required slight modifications to the v3 config library engines to adapt to aave-v2 different methods in the ILendingPoolConfigurator.

Missing tasks:
- [ ] tests
- [ ] update deploy scripts `scripts/AaveV2ConfigEngine.s.sol`